### PR TITLE
[#28] Chore: pxr 단위 구현 및 적용

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,16 +1,29 @@
 /** @type {import('tailwindcss').Config} */
+
+const pxToRem = (px, base = 16) => `${px / base}rem`;
+
+const range = (start, end) => {
+  return Array.from({ length: end - start + 1 }, (_, index) => index + start);
+};
+
 export default {
   content: ["./src/**/*.{js,jsx,ts,tsx}", "./index.html"],
   safelist: [
     { pattern: /w-/ },
-    { 
-      pattern: 
-        /bg-(primary|secondary|background|surface1|surface2|card|tooltip|toolbar|delete|tag)/, 
+    {
+      pattern:
+        /bg-(primary|secondary|background|surface1|surface2|card|tooltip|toolbar|delete|tag)/,
     },
     { pattern: /text-(text-primary|text-secondary|white|black|neutral)/ },
   ],
   theme: {
     extend: {
+      spacing: {
+        ...range(1, 1400).reduce((accumulate, px) => {
+          accumulate[`${px}pxr`] = pxToRem(px);
+          return accumulate;
+        }, {}),
+      },
       colors: {
         white: "#FFFFFF",
         black: "#000000",


### PR DESCRIPTION
## 📝 작업 내용

1. px을 rem으로 변환하는 함수 구현
2. 1-1400px까지 px을 모두 rem으로 변환

개발할때 편한건 px 단위인데, 접근성을 생각하면 rem 단위를 사용하는 것이 좋습니다!
그런데, tailwind에서 전체 폰트 사이즈를 62.5%로 하면 tailwind 전체 폰트 사이즈가 모두 줄어들어 매우 작게 보이더라구요ㅠ
저희 프로젝트가 디자이너가 있는 프로젝트가 아니라 이 점이 매우 불편할 것 같아 새로운 pxr 단위를 도입해 사용하는 것이 좋을 것 같았습니다.

개발할때 편한 px 단위로 사용하되, 실제 적용되는 것은 px이 아닌 rem이 되도록 변환해주었습니다.
특정 px 값을 width, height, padding, margin 등에 적용하고 싶을때 아래와 같이 사용해주시면 됩니다.

```js
w-100pxr h-200pxr
```

# 📍 기타 

제 아이디어는 아니고 저도 카카오에서 사용하는 것을 가져왔습니다ㅎㅎ
https://fe-developers.kakaoent.com/2022/221013-tailwind-and-design-system/

close #28 
