### PR TITLE
[#26] Feat: 태그 검색 컴포넌트 구현

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -83,6 +83,5 @@ module.exports = {
         pathGroupsExcludedImportTypes: ["builtin"],
       },
     ],
-    "prettier/prettier": ["error"],
   },
 };

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "husky": "^8.0.0",
     "lint-staged": "^15.2.2",
     "postcss": "^8.4.35",
-    "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.11",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,9 +103,6 @@ devDependencies:
   postcss:
     specifier: ^8.4.35
     version: 8.4.35
-  prettier:
-    specifier: ^3.2.5
-    version: 3.2.5
   prettier-plugin-tailwindcss:
     specifier: ^0.5.11
     version: 0.5.11(prettier@3.2.5)

--- a/src/components/common/RecommendTag.tsx
+++ b/src/components/common/RecommendTag.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/utils/tailwind";
+import TagBadge from "./TagBadge";
+
+interface Props {
+  className?: string;
+}
+
+const RecommendTag = ({ className }: Props) => {
+  // TODO: [2024.02.14] api 요청 예정
+  const recommendTags = ["분노", "스트레스", "박명수", "직장인", "잠좀자자"];
+
+  return (
+    <div className={cn("mb-4", className)}>
+      <div className="mb-4 text-sm font-bold">내가 가장 많이 사용한 태그</div>
+      <ul className="ml-2 flex w-[650px] flex-wrap gap-2 after:block after:w-[650px] after:border-b after:border-black after:content-['']">
+        {recommendTags.map((recommendTag) => (
+          <li className="mb-2">
+            <TagBadge content={recommendTag} isClickable />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default RecommendTag;

--- a/src/components/common/RecommendTag.tsx
+++ b/src/components/common/RecommendTag.tsx
@@ -12,9 +12,9 @@ const RecommendTag = ({ className }: Props) => {
   return (
     <div className={cn("mb-4", className)}>
       <div className="mb-4 text-sm font-bold">내가 가장 많이 사용한 태그</div>
-      <ul className="ml-2 flex w-[650px] flex-wrap gap-2 after:block after:w-[650px] after:border-b after:border-black after:content-['']">
-        {recommendTags.map((recommendTag) => (
-          <li className="mb-2">
+      <ul className="ml-2 flex w-650pxr flex-wrap gap-2 after:block after:w-650pxr after:border-b after:border-black after:content-['']">
+        {recommendTags.map((recommendTag, index) => (
+          <li key={`${index}-${recommendTag}`} className="mb-2">
             <TagBadge content={recommendTag} isClickable />
           </li>
         ))}

--- a/src/components/common/TagBadge.tsx
+++ b/src/components/common/TagBadge.tsx
@@ -1,6 +1,6 @@
 import { useAtom } from "jotai";
 import { cn } from "@/utils/tailwind";
-import { $toggleTag } from "@/store/tag";
+import { $selectedTags } from "@/store/tag";
 
 interface Props {
   content: string;
@@ -9,14 +9,23 @@ interface Props {
   className?: string;
 }
 
+const MAX_TAG = 5;
+
 const TagBadge = ({ content, isClickable = false, className }: Props) => {
-  const [selectedTag, toggleTag] = useAtom($toggleTag);
-  const isSelectedTag = selectedTag.includes(content);
+  const [selectedTags, setSelectedTags] = useAtom($selectedTags);
+  const isSelectedTag = selectedTags.includes(content);
 
   const handleClickTag = () => {
     if (!isClickable) return;
 
-    toggleTag(content);
+    if (selectedTags.includes(content)) {
+      setSelectedTags(selectedTags.filter((selectedTag) => selectedTag !== content));
+      return;
+    }
+
+    if (selectedTags.length < MAX_TAG) {
+      setSelectedTags((previousState) => [...previousState, content]);
+    }
   };
 
   const badgeClasses = cn("rounded-2xl px-4 py-2 text-white font-bold bg-tag", {

--- a/src/components/common/TagBadge.tsx
+++ b/src/components/common/TagBadge.tsx
@@ -1,6 +1,7 @@
 import { useAtom } from "jotai";
 import { cn } from "@/utils/tailwind";
 import { $selectedTags } from "@/store/tag";
+import { MAX_SEARCH_TAG } from "@/constants/tag";
 
 interface Props {
   content: string;
@@ -8,8 +9,6 @@ interface Props {
   onClick?: () => void;
   className?: string;
 }
-
-const MAX_TAG = 5;
 
 const TagBadge = ({ content, isClickable = false, className }: Props) => {
   const [selectedTags, setSelectedTags] = useAtom($selectedTags);
@@ -23,7 +22,7 @@ const TagBadge = ({ content, isClickable = false, className }: Props) => {
       return;
     }
 
-    if (selectedTags.length < MAX_TAG) {
+    if (selectedTags.length < MAX_SEARCH_TAG) {
       setSelectedTags((previousState) => [...previousState, content]);
     }
   };

--- a/src/components/common/TagBadge.tsx
+++ b/src/components/common/TagBadge.tsx
@@ -1,0 +1,35 @@
+import { useAtom } from "jotai";
+import { cn } from "@/utils/tailwind";
+import { $toggleTag } from "@/store/tag";
+
+interface Props {
+  content: string;
+  isClickable?: boolean;
+  onClick?: () => void;
+  className?: string;
+}
+
+const TagBadge = ({ content, isClickable = false, className }: Props) => {
+  const [selectedTag, toggleTag] = useAtom($toggleTag);
+  const isSelectedTag = selectedTag.includes(content);
+
+  const handleClickTag = () => {
+    if (!isClickable) return;
+
+    toggleTag(content);
+  };
+
+  const badgeClasses = cn("rounded-2xl px-4 py-2 text-white font-bold bg-tag", {
+    "cursor-pointer": isClickable,
+    "bg-gray-400": isClickable && !isSelectedTag,
+    "bg-tag": isSelectedTag,
+  });
+
+  return (
+    <span onClick={handleClickTag} className={cn(badgeClasses, className)}>
+      {content}
+    </span>
+  );
+};
+
+export default TagBadge;

--- a/src/components/common/TagSearchForm.tsx
+++ b/src/components/common/TagSearchForm.tsx
@@ -3,12 +3,11 @@ import { useAtom } from "jotai";
 import { XCircle, Search } from "lucide-react";
 import { cn } from "@/utils/tailwind";
 import { $selectedTags } from "@/store/tag";
+import { MAX_SEARCH_TAG } from "@/constants/tag";
 
 interface Props {
   className?: string;
 }
-
-const MAX_TAG = 5;
 
 const TagSearchForm = ({ className }: Props) => {
   const [selectedTags, setSelectedTags] = useAtom($selectedTags);
@@ -20,7 +19,7 @@ const TagSearchForm = ({ className }: Props) => {
     const tag = formData.get("tag") as string;
     const input = event.currentTarget.elements.namedItem("tag") as HTMLInputElement;
 
-    if (selectedTags.length < MAX_TAG && !selectedTags.includes(tag)) {
+    if (selectedTags.length < MAX_SEARCH_TAG && !selectedTags.includes(tag)) {
       setSelectedTags((previousState) => [...previousState, tag]);
     }
 

--- a/src/components/common/TagSearchForm.tsx
+++ b/src/components/common/TagSearchForm.tsx
@@ -20,37 +20,47 @@ const TagSearchForm = ({ className }: Props) => {
     const tag = formData.get("tag") as string;
     const input = event.currentTarget.elements.namedItem("tag") as HTMLInputElement;
 
-    if (selectedTags.length >= MAX_TAG || selectedTags.includes(tag)) {
-      return;
+    if (selectedTags.length < MAX_TAG && !selectedTags.includes(tag)) {
+      setSelectedTags((previousState) => [...previousState, tag]);
     }
-
-    setSelectedTags((previousState) => [...previousState, tag]);
 
     input.value = "";
   };
 
-  const handleClickDeleteTag = (deleteTag: string) => () => {
-    setSelectedTags(selectedTags.filter((selectedTag) => selectedTag !== deleteTag));
+  const handleClickDeleteTag = (tag: string) => () => {
+    setSelectedTags(selectedTags.filter((selectedTag) => selectedTag !== tag));
+  };
+
+  const handleClickResetTagButton = () => {
+    setSelectedTags([]);
   };
 
   return (
-    <div className={cn(`flex min-w-[607px] flex-col flex-wrap `, className)}>
+    // TODO: [2024.02.14] px 추후 pxr로 변환
+    <div className={cn(`flex w-[650px] flex-col flex-wrap `, className)}>
       <form onSubmit={handleSubmitForm}>
         <label htmlFor="tagInput" className="a11y-hidden">
           태그 입력
         </label>
-        <div className=" flex flex-wrap items-center rounded-3xl border border-black px-5 py-2">
+        <div className=" flex max-w-[700px] flex-wrap  items-center rounded-3xl border border-black px-4">
           <input
             id="tagInput"
             name="tag"
             className="min-h-16 flex-1 rounded-xl border-none bg-transparent outline-none"
           />
+
+          {selectedTags.length > 0 && (
+            <button onClick={handleClickResetTagButton} className="mr-4" type="button">
+              <XCircle />
+            </button>
+          )}
+
           <button type="submit">
             <Search aria-label="검색" />
           </button>
         </div>
       </form>
-      <ul className="mt-4 flex items-center pl-2">
+      <ul className="mt-4 flex min-h-8 flex-wrap items-center gap-2 pl-2">
         {selectedTags.map((selectedTag, index) => (
           <li
             key={`${index}-${selectedTag}`}

--- a/src/components/common/TagSearchForm.tsx
+++ b/src/components/common/TagSearchForm.tsx
@@ -41,7 +41,7 @@ const TagSearchForm = ({ className }: Props) => {
         <label htmlFor="tagInput" className="a11y-hidden">
           태그 입력
         </label>
-        <div className=" flex max-w-650pxr flex-wrap  items-center rounded-3xl border border-black px-4">
+        <div className="flex max-w-650pxr flex-wrap items-center rounded-3xl border border-black px-4">
           <input
             id="tagInput"
             name="tag"

--- a/src/components/common/TagSearchForm.tsx
+++ b/src/components/common/TagSearchForm.tsx
@@ -1,0 +1,72 @@
+import { FormEvent } from "react";
+import { useAtom } from "jotai";
+import { XCircle, Search } from "lucide-react";
+import { cn } from "@/utils/tailwind";
+import { $selectedTags } from "@/store/tag";
+
+interface Props {
+  className?: string;
+}
+
+const MAX_TAG = 5;
+
+const TagSearchForm = ({ className }: Props) => {
+  const [selectedTags, setSelectedTags] = useAtom($selectedTags);
+
+  const handleSubmitForm = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const formData = new FormData(event.currentTarget);
+    const tag = formData.get("tag") as string;
+    const input = event.currentTarget.elements.namedItem("tag") as HTMLInputElement;
+
+    if (selectedTags.length >= MAX_TAG || selectedTags.includes(tag)) {
+      return;
+    }
+
+    setSelectedTags((previousState) => [...previousState, tag]);
+
+    input.value = "";
+  };
+
+  const handleClickDeleteTag = (deleteTag: string) => () => {
+    setSelectedTags(selectedTags.filter((selectedTag) => selectedTag !== deleteTag));
+  };
+
+  return (
+    <div className={cn(`flex min-w-[607px] flex-col flex-wrap `, className)}>
+      <form onSubmit={handleSubmitForm}>
+        <label htmlFor="tagInput" className="a11y-hidden">
+          태그 입력
+        </label>
+        <div className=" flex flex-wrap items-center rounded-3xl border border-black px-5 py-2">
+          <input
+            id="tagInput"
+            name="tag"
+            className="min-h-16 flex-1 rounded-xl border-none bg-transparent outline-none"
+          />
+          <button type="submit">
+            <Search aria-label="검색" />
+          </button>
+        </div>
+      </form>
+      <ul className="mt-4 flex items-center pl-2">
+        {selectedTags.map((selectedTag, index) => (
+          <li
+            key={`${index}-${selectedTag}`}
+            className="mr-2 flex items-center rounded-3xl bg-tag px-2 py-1 text-white"
+          >
+            {selectedTag}
+            <XCircle
+              onClick={handleClickDeleteTag(selectedTag)}
+              aria-label="태그 삭제"
+              className="ml-1 w-5 cursor-pointer"
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TagSearchForm;

--- a/src/components/common/TagSearchForm.tsx
+++ b/src/components/common/TagSearchForm.tsx
@@ -36,13 +36,12 @@ const TagSearchForm = ({ className }: Props) => {
   };
 
   return (
-    // TODO: [2024.02.14] px 추후 pxr로 변환
-    <div className={cn(`flex w-[650px] flex-col flex-wrap `, className)}>
+    <div className={cn(`flex w-650pxr flex-col flex-wrap `, className)}>
       <form onSubmit={handleSubmitForm}>
         <label htmlFor="tagInput" className="a11y-hidden">
           태그 입력
         </label>
-        <div className=" flex max-w-[700px] flex-wrap  items-center rounded-3xl border border-black px-4">
+        <div className=" flex max-w-650pxr flex-wrap  items-center rounded-3xl border border-black px-4">
           <input
             id="tagInput"
             name="tag"

--- a/src/components/common/TagSearchForm.tsx
+++ b/src/components/common/TagSearchForm.tsx
@@ -52,26 +52,29 @@ const TagSearchForm = ({ className }: Props) => {
           </button>
         </div>
       </form>
-      <ul className="flex-column mt-4 flex min-h-8 flex-wrap items-center gap-2 pl-2">
-        {selectedTags.map((selectedTag, index) => (
-          <li
-            key={`${index}-${selectedTag}`}
-            className="mr-2 flex items-center rounded-3xl bg-tag px-2 py-1 text-white"
-          >
-            {selectedTag}
-            <XCircle
-              onClick={handleClickDeleteTag(selectedTag)}
-              aria-label="태그 삭제"
-              className="ml-1 w-5 cursor-pointer"
-            />
-          </li>
-        ))}
-      </ul>
-      {selectedTags.length > 0 && (
-        <button onClick={handleClickResetTagButton} className="flex-column mr-4 flex" type="button">
-          <RotateCw aria-label="태그 초기화" />
-        </button>
-      )}
+      <div className="flex items-center">
+        {selectedTags.length > 0 && (
+          <button onClick={handleClickResetTagButton} className=" mr-4 mt-4 pl-4" type="button">
+            <RotateCw aria-label="태그 초기화" />
+          </button>
+        )}
+
+        <ul className="flex-column mt-4 flex min-h-8 flex-wrap items-center justify-center gap-2 pl-1">
+          {selectedTags.map((selectedTag, index) => (
+            <li
+              key={`${index}-${selectedTag}`}
+              className="mr-2 flex items-center rounded-3xl bg-tag px-2 py-1 text-white"
+            >
+              {selectedTag}
+              <XCircle
+                onClick={handleClickDeleteTag(selectedTag)}
+                aria-label="태그 삭제"
+                className="ml-1 w-5 cursor-pointer"
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 };

--- a/src/components/common/TagSearchForm.tsx
+++ b/src/components/common/TagSearchForm.tsx
@@ -1,6 +1,6 @@
 import { FormEvent } from "react";
 import { useAtom } from "jotai";
-import { XCircle, Search } from "lucide-react";
+import { XCircle, Search, RotateCw } from "lucide-react";
 import { cn } from "@/utils/tailwind";
 import { $selectedTags } from "@/store/tag";
 import { MAX_SEARCH_TAG } from "@/constants/tag";
@@ -47,18 +47,12 @@ const TagSearchForm = ({ className }: Props) => {
             className="min-h-16 flex-1 rounded-xl border-none bg-transparent outline-none"
           />
 
-          {selectedTags.length > 0 && (
-            <button onClick={handleClickResetTagButton} className="mr-4" type="button">
-              <XCircle />
-            </button>
-          )}
-
           <button type="submit">
             <Search aria-label="검색" />
           </button>
         </div>
       </form>
-      <ul className="mt-4 flex min-h-8 flex-wrap items-center gap-2 pl-2">
+      <ul className="flex-column mt-4 flex min-h-8 flex-wrap items-center gap-2 pl-2">
         {selectedTags.map((selectedTag, index) => (
           <li
             key={`${index}-${selectedTag}`}
@@ -73,6 +67,11 @@ const TagSearchForm = ({ className }: Props) => {
           </li>
         ))}
       </ul>
+      {selectedTags.length > 0 && (
+        <button onClick={handleClickResetTagButton} className="flex-column mr-4 flex" type="button">
+          <RotateCw aria-label="태그 초기화" />
+        </button>
+      )}
     </div>
   );
 };

--- a/src/constants/tag.ts
+++ b/src/constants/tag.ts
@@ -1,0 +1,1 @@
+export const MAX_SEARCH_TAG = 5;

--- a/src/store/tag.ts
+++ b/src/store/tag.ts
@@ -1,0 +1,3 @@
+import { atom } from "jotai";
+
+export const $selectedTags = atom<string[]>([]);


### PR DESCRIPTION
## 📝 작업 내용

1. 태그 검색 컴포넌트 구현
검색어를 입력하거나 검색 추천 컴포넌트와 자동완성에서 선택할때마다 선택된 검색 태그가 바뀌어야 합니다.
선택된 태그를 atom으로 관리하여 서로 다른 컴포넌트에서 변경할 수 있게 해주었습니다.

2. tag badge 컴포넌트 구현
추천 태그를 보여주는 부분에서 사용될 단순 UI를 담당하는 TagBadge 컴포넌트를 구현했습니다.

<img width="185" alt="스크린샷 2024-02-14 오후 9 50 34" src="https://github.com/zzalmyu/zzalmyu-frontend/assets/61978339/392addbb-710e-46b0-a7ca-c3bc3afc4f3f">

3. 추천 검색어를 보여주는 컴포넌트 구현
<img width="685" alt="스크린샷 2024-02-14 오후 9 51 07" src="https://github.com/zzalmyu/zzalmyu-frontend/assets/61978339/799abfaf-144c-4417-a7c5-0ba015310b05">


### 📷 스크린샷
![화면 기록 2024-02-14 오후 6 33 34](https://github.com/zzalmyu/zzalmyu-frontend/assets/61978339/7930bb15-dc39-4ee2-8511-7f3400b7a0cc)


## 💬 리뷰 요구사항
1. 태그들이 input 안에 없다보니 태그 초기화 버튼의 위치가 애매한 것 같아요. 바꾸면 좋을거 같은데 어디에 위치시킬까요?

# 📍 기타

1. 태그 검색 컴포넌트에서 사용되는 태그는 `TagBadge` 컴포넌트를 사용하지 않았습니다. 태그를 입력하고 엔터쳤을때 나오는 태그를 토글할 수 있다면 `TagBadge` 컴포넌트를 사용해도 될 것 같아요!



close #26
