### PR TITLE
[#39] Fix: 공통 컴포넌트(ZzalCard)의 props 수정

### DIFF
--- a/src/components/common/ZzalCard.tsx
+++ b/src/components/common/ZzalCard.tsx
@@ -6,7 +6,7 @@ interface ZzalCardProps {
   src: string;
   alt: string;
   isChatImage?: boolean;
-  width?: number;
+  width?: number | string;
 }
 
 const ZzalCard = ({ children, src, alt, width = 72, isChatImage = false }: ZzalCardProps) => {

--- a/src/components/common/ZzalCard.tsx
+++ b/src/components/common/ZzalCard.tsx
@@ -5,18 +5,18 @@ interface ZzalCardProps {
   children?: ReactNode;
   src: string;
   alt: string;
-  isChatImage?: boolean;
+  hasAnimation?: boolean;
   width?: number | string;
 }
 
-const ZzalCard = ({ children, src, alt, width = 72, isChatImage = false }: ZzalCardProps) => {
+const ZzalCard = ({ children, src, alt, width = 72, hasAnimation = true }: ZzalCardProps) => {
   return (
     <div className={`group relative w-${width} rounded-lg bg-base-100 shadow-xl`}>
       <div className="button-container absolute right-2 top-1 z-10 w-fit opacity-0 transition-opacity duration-500 ease-in-out group-hover:opacity-100">
         {children}
       </div>
       <figure
-        className={`${isChatImage ? "none" : "transition duration-300 ease-in-out hover:brightness-75"}`}
+        className={`${hasAnimation ? "transition duration-300 ease-in-out hover:brightness-75" : "none"}`}
       >
         <img src={src} alt={alt} className="h-full w-full rounded-lg object-cover" />
       </figure>


### PR DESCRIPTION
## 📝 작업 내용

> 공통 이미지 컴포넌트를 여러 페이지에서 사용하지 못하는 닫힌 확장성을 개선 하였습니다.

```javascript
interface ZzalCardProps {
  children?: ReactNode;
  src: string;
  alt: string;
  hasAnimation?: boolean; // isChatImage -> hasAnimation
  width?: number | string; // number -> number | string
}

const ZzalCard = ({ children, src, alt, width = 72, hasAnimation = true }: ZzalCardProps)
```
기존 width의 number타입을 number | string 타입으로 확장했고,
isChatImage prop의 네이밍을 hasAnimation으로 변경하여 애니메이션 on/off 여부를 설정할 수 있게 변경하였습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

# 📍 기타 (선택)

> 다른 분들이 참고해야할 사항이 있다면 작성해주세요

close #39
