### PR TITLE
[#44] Style: 공통 Outlet layout 구현

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,11 +6,9 @@ import Header from "@/components/common/Header";
 const RootComponent = () => {
   return (
     <Fragment>
-      <div className="flex max-h-screen min-h-screen flex-col overflow-hidden pb-10">
-        <Header />
-        <div className="max-h-full min-h-full overflow-auto px-10 pt-10">
-          <Outlet />
-        </div>
+      <Header />
+      <div className="p-40pxr">
+        <Outlet />
       </div>
     </Fragment>
   );

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,8 +6,12 @@ import Header from "@/components/common/Header";
 const RootComponent = () => {
   return (
     <Fragment>
-      <Header />
-      <Outlet />
+      <div className="flex max-h-screen min-h-screen flex-col overflow-hidden pb-10">
+        <Header />
+        <div className="max-h-full min-h-full overflow-auto px-10 pt-10">
+          <Outlet />
+        </div>
+      </div>
     </Fragment>
   );
 };


### PR DESCRIPTION
## 📝 작업 내용
 - css `screen` 속성으로 뷰포트 비율에 맞춰 `div` 영역 지정
    - 뷰포트 : 해당 웹페이지를 실행하고 있는 기기의 화면크기

- 헤더를 제외한 Outlet 영역에 전체 padding 10 지정

## 📷 스크린샷 (선택)
<img width="549" alt="image" src="https://github.com/zzalmyu/zzalmyu-frontend/assets/82134668/bcdf60fb-3e3e-4e11-9c3c-f8cb4a879f24">


## 💬 리뷰 요구사항(선택)

- `Header`가 아닌, 화면이 변경되는 `Outlet` 영역에 전체 `padding`을 `10`만큼 주었는데, 우선 이미지가 길어지는 경우에도 `bottom`에 `padding`이 있는 것이 어색하지 않을 것 같아서 공통으로 주었습니다.
- `padding bottom`을 `0`으로 두는 것이 더 좋을 것 같다면 말씀해주세요:)

## 📍 기타 (선택)

> 다른 분들이 참고해야할 사항이 있다면 작성해주세요

close #44