### PR TITLE
[#48] Fix: 드롭다운 메뉴 동작 및 버튼 색상 버그 수정

### DIFF
--- a/src/components/common/Header/DropdownMenu.tsx
+++ b/src/components/common/Header/DropdownMenu.tsx
@@ -52,11 +52,8 @@ const DropdownMenu = ({ user }: Props) => {
               <li key={`${index}-${name}`} className="group" onClick={toggleDetails}>
                 <Link
                   to={path}
-                  activeProps={{
-                    style: {
-                      background: "transparent",
-                    },
-                  }}
+                  className="[&.active]:text-white "
+                  activeProps={{ className: "bg-transparent" }}
                 >
                   <div className="h-6 w-6 group-hover:text-blue-500">
                     <Icon size={20} aria-label={name} />

--- a/src/components/common/Header/DropdownMenu.tsx
+++ b/src/components/common/Header/DropdownMenu.tsx
@@ -1,5 +1,7 @@
+import { useRef } from "react";
 import { Home, Heart, FolderUp, LogOut } from "lucide-react";
 import { Link } from "@tanstack/react-router";
+
 interface Props {
   user: {
     name: string;
@@ -30,17 +32,32 @@ const DropdownMenu = ({ user }: Props) => {
     },
   ];
 
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+
+  const toggleDetails = () => {
+    if (detailsRef.current) {
+      detailsRef.current.open = !detailsRef.current.open;
+    }
+  };
+
   return (
-    <ul className="menu menu-horizontal px-0 ">
+    <ul className="menu menu-horizontal px-0">
       <li>
-        <details>
-          <summary className="h-9 font-bold text-text-primary hover:bg-gray-300 focus:bg-transparent ">
+        <details ref={detailsRef}>
+          <summary className="h-9 font-bold text-text-primary hover:bg-gray-300 focus:bg-transparent">
             {user.name}
           </summary>
           <ul className="right-1 z-[1] w-44 rounded-box bg-background text-text-primary ">
             {menuItems.map(({ path, Icon, name }, index) => (
-              <li key={`${index}-${name}`} className="group">
-                <Link to={path}>
+              <li key={`${index}-${name}`} className="group" onClick={toggleDetails}>
+                <Link
+                  to={path}
+                  activeProps={{
+                    style: {
+                      background: "transparent",
+                    },
+                  }}
+                >
                   <div className="h-6 w-6 group-hover:text-blue-500">
                     <Icon size={20} aria-label={name} />
                   </div>


### PR DESCRIPTION
## 📝 작업 내용

> 버그
- 헤더 드롭다운 메뉴 안에 daisy UI 기본버튼의 active 속성이 Link태그로 인해 활성화되어 의도치 않은 색상 변경이 일어납니다.
- 메뉴클릭 시 드롭다운 메뉴가 자동으로 닫히는 기능을 추가해야합니다.
![image](https://github.com/zzalmyu/zzalmyu-frontend/assets/107539614/3da097dd-aa40-4b39-81ef-6cb7d2284fad)

> 해결
- Link activeProps에 배경속성을 transparent로 변경했습니다.
- toggleDetails함수를 만들어 메뉴 클릭후 페이지 이동시 리렌더링 없이 메뉴가 닫히도록 했습니다.

### 📷 스크린샷 (선택)

https://github.com/zzalmyu/zzalmyu-frontend/assets/107539614/0cce16c2-a422-4643-8f53-3302fbeccc6f


## 💬 리뷰 요구사항(선택)

> 함수명이 적절한지 봐주시면 감사하겠습니당

# 📍 기타 (선택)

> [daisyUI dropdown](https://daisyui.com/components/dropdown/)

close #48 
