### PR TITLE
[#52] Feat: 태그 '검색 결과가 없음'을 나타내는 컴포넌트 구현

### DIFF
--- a/src/components/common/NoSearchResults.tsx
+++ b/src/components/common/NoSearchResults.tsx
@@ -4,7 +4,7 @@ interface Props {
   onClick: (isTagReset: boolean) => void;
 }
 
-const NotSearch = ({ onClick }: Props) => {
+const NoSearchResults = ({ onClick }: Props) => {
   return (
     <div className="flex h-400pxr w-[35%] min-w-96 flex-col items-center rounded-xl bg-card">
       <SearchX aria-label="검색 실패" size={60} className="mt-80pxr" />
@@ -20,4 +20,4 @@ const NotSearch = ({ onClick }: Props) => {
   );
 };
 
-export default NotSearch;
+export default NoSearchResults;

--- a/src/components/common/NotSearch.tsx
+++ b/src/components/common/NotSearch.tsx
@@ -1,7 +1,7 @@
 import { SearchX } from "lucide-react";
 
 interface Props {
-  onClick: (inputValue: string) => void;
+  onClick: (isTagReset: boolean) => void;
 }
 
 const NotSearch = ({ onClick }: Props) => {
@@ -12,7 +12,7 @@ const NotSearch = ({ onClick }: Props) => {
       <p className="mt-20pxr text-text-secondary">필터를 삭제하고 다시 시도해보세요.</p>
       <button
         className="mt-40pxr h-40pxr w-180pxr rounded-full bg-primary text-white"
-        onClick={() => onClick("")}
+        onClick={() => onClick(true)}
       >
         되돌아가기
       </button>

--- a/src/components/common/NotSearch.tsx
+++ b/src/components/common/NotSearch.tsx
@@ -1,0 +1,23 @@
+import { SearchX } from "lucide-react";
+
+interface Props {
+  onClick: (inputValue: string) => void;
+}
+
+const NotSearch = ({ onClick }: Props) => {
+  return (
+    <div className="flex h-400pxr w-[35%] min-w-96 flex-col items-center rounded-xl bg-card">
+      <SearchX aria-label="검색 실패" size={60} className="mt-80pxr" />
+      <p className="mt-35pxr text-4xl">검색 결과가 없어요!</p>
+      <p className="mt-20pxr text-text-secondary">필터를 삭제하고 다시 시도해보세요.</p>
+      <button
+        className="mt-40pxr h-40pxr w-180pxr rounded-full bg-primary text-white"
+        onClick={() => onClick("")}
+      >
+        되돌아가기
+      </button>
+    </div>
+  );
+};
+
+export default NotSearch;


### PR DESCRIPTION
## 📝 작업 내용

> 홈, 내가 좋아요/업로드 한 짤에서 태그 검색 후 검색 결과가 없을 시 나타나는 컴포넌트를 구현하였습니다.
- 아직 #36 PR이 merge 되지 않아 컴포넌트의 크기를 임의로 지정하였습니다. 이 부분은 #36 PR이 merge 된 후 다시 수정 하겠습니다.
- `onClick` prop은 콜백 함수로 되돌아가기 버튼을 눌렀을 시 모든 태그와 `input` 엘리먼트의 value를 초기화 시키는 방향으로 고민하여 boolean 타입으로설정하였습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
- onClick 함수 prop을 커링으로 받아야할지 고민하다 일단은 일반함수로 받도록 구현하였습니다. 이 부분에 대해서도 이야기해보면 좋을 것 같아요!
# 📍 기타 (선택)

close #52
