### PR TITLE
[#51] Feat: useIntersectionObserver 훅 구현

### DIFF
--- a/src/hooks/common/useIntersectionObserver.ts
+++ b/src/hooks/common/useIntersectionObserver.ts
@@ -1,0 +1,43 @@
+import { RefObject, useEffect, useRef } from "react";
+
+interface Props {
+  target: RefObject<Element>;
+  handleIntersect: (element: Element) => void;
+  options?: IntersectionObserverInit;
+}
+
+const defaultOptions = {
+  root: null,
+  rootMargin: "0px",
+  threshold: 0.1,
+};
+
+const useIntersectionObserver = ({
+  target,
+  handleIntersect,
+  options = defaultOptions,
+}: Props): RefObject<IntersectionObserver | null> => {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    if (!target.current) return;
+
+    observerRef.current = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          handleIntersect(entry.target);
+        }
+      });
+    }, options);
+
+    observerRef.current.observe(target.current);
+
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, [target, handleIntersect, options]);
+
+  return observerRef;
+};
+
+export default useIntersectionObserver;

--- a/src/hooks/common/useIntersectionObserver.ts
+++ b/src/hooks/common/useIntersectionObserver.ts
@@ -35,7 +35,7 @@ const useIntersectionObserver = ({
     return () => {
       observerRef.current?.disconnect();
     };
-  }, [target, handleIntersect, options]);
+  }, [target, options]);
 
   return observerRef;
 };

--- a/src/hooks/common/useIntersectionObserver.ts
+++ b/src/hooks/common/useIntersectionObserver.ts
@@ -1,6 +1,6 @@
 import { RefObject, useEffect, useRef } from "react";
 
-interface Props {
+interface Parameters {
   target: RefObject<Element>;
   handleIntersect: (element: Element) => void;
   options?: IntersectionObserverInit;
@@ -16,7 +16,7 @@ const useIntersectionObserver = ({
   target,
   handleIntersect,
   options = defaultOptions,
-}: Props): RefObject<IntersectionObserver | null> => {
+}: Parameters): RefObject<IntersectionObserver | null> => {
   const observerRef = useRef<IntersectionObserver | null>(null);
 
   useEffect(() => {

--- a/src/hooks/common/useIntersectionObserver.ts
+++ b/src/hooks/common/useIntersectionObserver.ts
@@ -6,7 +6,7 @@ interface Parameters {
   options?: IntersectionObserverInit;
 }
 
-const defaultOptions = {
+const DEFAULT_OPTIONS = {
   root: null,
   rootMargin: "0px",
   threshold: 0.1,
@@ -15,7 +15,7 @@ const defaultOptions = {
 const useIntersectionObserver = ({
   target,
   handleIntersect,
-  options = defaultOptions,
+  options = DEFAULT_OPTIONS,
 }: Parameters): RefObject<IntersectionObserver | null> => {
   const observerRef = useRef<IntersectionObserver | null>(null);
 


### PR DESCRIPTION
## 📝 작업 내용

1. 무한 스크롤에 사용될 `useIntersectionObserver` 훅을 구현했습니다.
target 요소 (RefObject), handleIntersect 콜백 함수, 그리고 Observer options를 파라미터로 받습니다.

options로 지정할 수 있는 값들은 아래의 값들입니다.

- root: 교차 영역을 계산할 때 사용되는 뷰포트 요소를 지정합니다. 기본값은 null이며, 이 경우 브라우저의 뷰포트가 사용됩니다.

- rootMargin: root 요소의 마진을 지정합니다. 이 마진은 root가 가지고 있는 뷰포트 영역을 확장하거나 축소합니다. 값은 CSS의 margin 속성과 유사하게 top right bottom left 형태로 지정할 수 있으며, 기본값은 "0px 0px 0px 0px"입니다.

- threshold: 타겟 요소가 얼마나 교차되었을 때 콜백 함수를 실행할 것인지를 결정하는 값입니다. 예를 들어, 0.1은 타겟 요소의 10%가 교차될 때 콜백이 실행되도록 합니다. 배열을 사용하면 여러 교차 비율에서 콜백을 실행할 수 있습니다. 기본값은 0으로 두었습니다.


 타겟 요소가 교차할 때 handleIntersect 콜백 함수를 실행합니다.

close #51
