### PR TITLE
[#60] Fix: 태그 검색 시 자동완성 UI에 포커싱되어 검색창의 포커싱이 풀리는 버그 수정

### DIFF
--- a/src/components/common/TagAutoComplete.tsx
+++ b/src/components/common/TagAutoComplete.tsx
@@ -1,14 +1,13 @@
 import { useEffect, useState } from "react";
 import { cn } from "@/utils/tailwind";
 import { Tag } from "@/types/tag";
-import { Tags } from "@/types/tags";
 
 interface Props {
-  tags: Tags;
+  tags: Tag[];
   onSelectTagName: (tag: Tag) => void;
 }
 
-const TagAutoComplete = ({ tags = [], onSelectTagName }: Props) => {
+const TagAutoComplete = ({ tags, onSelectTagName }: Props) => {
   const [cursorIndex, setCursorIndex] = useState(0);
 
   const handleClickTagName = (tagIndex: number) => () => {

--- a/src/components/common/TagAutoComplete.tsx
+++ b/src/components/common/TagAutoComplete.tsx
@@ -62,16 +62,16 @@ const TagAutoComplete = ({ tags = [], onSelectTagName }: Props) => {
         </li>
       )}
       {tags.length > 0 &&
-        tags.map((tag, index) => (
+        tags.map(({ tagId, tagName }, index) => (
           <li
-            key={`${index}-${tag}`}
+            key={`${tagId}`}
             className={cn(
-              `${index === cursorIndex && "bg-gray-200 font-bold"}  box-border rounded-md px-1.5 py-2`,
+              `${index === cursorIndex && "bg-gray-200 font-bold"} box-border rounded-md px-1.5 py-2`,
             )}
             onMouseOver={handleMouseOverTag(index)}
             onClick={handleClickTagName(index)}
           >
-            <div>{tag.tagName}</div>
+            <div>{tagName}</div>
           </li>
         ))}
     </ul>

--- a/src/components/common/TagAutoComplete.tsx
+++ b/src/components/common/TagAutoComplete.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { cn } from "@/utils/tailwind";
-import { GetTagsResponse } from "@/types/tag.dto";
+import { tag } from "@/types/tag";
+import { tags } from "@/types/tags";
 
 interface Props {
-  tags: GetTagsResponse[];
-  onSelectTagName: (tag: GetTagsResponse) => void;
+  tags: tags;
+  onSelectTagName: (tag: tag) => void;
 }
 
 const TagAutoComplete = ({ tags = [], onSelectTagName }: Props) => {

--- a/src/components/common/TagAutoComplete.tsx
+++ b/src/components/common/TagAutoComplete.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
 import { cn } from "@/utils/tailwind";
-import { tag } from "@/types/tag";
-import { tags } from "@/types/tags";
+import { Tag } from "@/types/tag";
+import { Tags } from "@/types/tags";
 
 interface Props {
-  tags: tags;
-  onSelectTagName: (tag: tag) => void;
+  tags: Tags;
+  onSelectTagName: (tag: Tag) => void;
 }
 
 const TagAutoComplete = ({ tags = [], onSelectTagName }: Props) => {

--- a/src/components/common/TagAutoComplete.tsx
+++ b/src/components/common/TagAutoComplete.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, KeyboardEvent } from "react";
+import { useEffect, useState } from "react";
 import { cn } from "@/utils/tailwind";
 
 interface Props {
@@ -8,28 +8,6 @@ interface Props {
 
 const TagAutoComplete = ({ tags = [], onSelectTagName }: Props) => {
   const [cursorIndex, setCursorIndex] = useState(0);
-  const ulRef = useRef<HTMLUListElement>(null);
-
-  const handleKeydownTagFocus = (event: KeyboardEvent<HTMLUListElement>) => {
-    const { key } = event;
-
-    if (key === "ArrowUp") {
-      setCursorIndex((cursor) => {
-        return cursor - 1 < 0 ? tags.length - 1 : cursor - 1;
-      });
-    }
-    if (key === "ArrowDown") {
-      setCursorIndex((cursor) => {
-        return cursor + 1 >= tags.length ? 0 : cursor + 1;
-      });
-    }
-  };
-
-  const handleKeyUpTagSelect = (event: KeyboardEvent<HTMLUListElement>) => {
-    const { key } = event;
-
-    if (key === "Enter") return onSelectTagName(tags[cursorIndex]);
-  };
 
   const handleClickTagName = (tagIndex: number) => () => {
     setCursorIndex(tagIndex);
@@ -38,19 +16,42 @@ const TagAutoComplete = ({ tags = [], onSelectTagName }: Props) => {
 
   const handleMouseOverTag = (tagIndex: number) => () => {
     setCursorIndex(tagIndex);
-    ulRef.current?.focus();
   };
 
   useEffect(() => {
-    ulRef.current?.focus();
-  }, []);
+    const handleKeydownTagFocus = (event: KeyboardEvent) => {
+      const { key } = event;
+
+      if (key === "ArrowUp") {
+        setCursorIndex((cursor) => {
+          return cursor - 1 < 0 ? tags.length - 1 : cursor - 1;
+        });
+      }
+      if (key === "ArrowDown") {
+        setCursorIndex((cursor) => {
+          return cursor + 1 >= tags.length ? 0 : cursor + 1;
+        });
+      }
+    };
+
+    const handleKeyUpTagSelect = (event: KeyboardEvent) => {
+      const { key } = event;
+
+      if (key === "Enter") return onSelectTagName(tags[cursorIndex]);
+    };
+
+    window.addEventListener("keydown", handleKeydownTagFocus);
+    window.addEventListener("keyup", handleKeyUpTagSelect);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeydownTagFocus);
+      window.removeEventListener("keyup", handleKeyUpTagSelect);
+    };
+  });
 
   return (
     <ul
       className="box-border w-4/5 rounded-box border-2 p-2 shadow-xl outline-none"
-      ref={ulRef}
-      onKeyDown={handleKeydownTagFocus}
-      onKeyUp={handleKeyUpTagSelect}
       onBlur={() => setCursorIndex(-1)}
       tabIndex={0}
     >

--- a/src/components/common/TagAutoComplete.tsx
+++ b/src/components/common/TagAutoComplete.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { cn } from "@/utils/tailwind";
+import { GetTagsResponse } from "@/types/tag.dto";
 
 interface Props {
-  tags: Array<string>;
-  onSelectTagName: (tagName: string) => void;
+  tags: GetTagsResponse[];
+  onSelectTagName: (tag: GetTagsResponse) => void;
 }
 
 const TagAutoComplete = ({ tags = [], onSelectTagName }: Props) => {
@@ -70,7 +71,7 @@ const TagAutoComplete = ({ tags = [], onSelectTagName }: Props) => {
             onMouseOver={handleMouseOverTag(index)}
             onClick={handleClickTagName(index)}
           >
-            <div>{tag}</div>
+            <div>{tag.tagName}</div>
           </li>
         ))}
     </ul>

--- a/src/components/common/TagAutoComplete.tsx
+++ b/src/components/common/TagAutoComplete.tsx
@@ -64,7 +64,7 @@ const TagAutoComplete = ({ tags = [], onSelectTagName }: Props) => {
       {tags.length > 0 &&
         tags.map(({ tagId, tagName }, index) => (
           <li
-            key={`${tagId}`}
+            key={tagId}
             className={cn(
               `${index === cursorIndex && "bg-gray-200 font-bold"} box-border rounded-md px-1.5 py-2`,
             )}

--- a/src/types/tag.dto.ts
+++ b/src/types/tag.dto.ts
@@ -1,4 +1,3 @@
-export interface GetTagsResponse {
-  tagId: 0;
-  tagName: string;
-}
+import { tag } from "./tag";
+
+export type GetTagsResponse = tag[];

--- a/src/types/tag.dto.ts
+++ b/src/types/tag.dto.ts
@@ -1,0 +1,4 @@
+export interface GetTagsResponse {
+  tagId: 0;
+  tagName: "string";
+}

--- a/src/types/tag.dto.ts
+++ b/src/types/tag.dto.ts
@@ -1,3 +1,3 @@
-import { tag } from "./tag";
+import { Tag } from "./tag";
 
-export type GetTagsResponse = tag[];
+export type GetTagsResponse = Tag[];

--- a/src/types/tag.dto.ts
+++ b/src/types/tag.dto.ts
@@ -1,4 +1,4 @@
 export interface GetTagsResponse {
   tagId: 0;
-  tagName: "string";
+  tagName: string;
 }

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -1,0 +1,4 @@
+export interface tag {
+  tagId: 0;
+  tagName: string;
+}

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -1,4 +1,4 @@
 export interface Tag {
-  tagId: 0;
+  tagId: number;
   tagName: string;
 }

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -1,4 +1,4 @@
-export interface tag {
+export interface Tag {
   tagId: 0;
   tagName: string;
 }

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -1,3 +1,3 @@
-import { tag } from "./tag";
+import { Tag } from "./tag";
 
-export type tags = tag[];
+export type Tags = Tag[];

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -1,3 +1,0 @@
-import { Tag } from "./tag";
-
-export type Tags = Tag[];

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -1,0 +1,3 @@
+import { tag } from "./tag";
+
+export type tags = tag[];


### PR DESCRIPTION
## 📝 작업 내용

> [#60] Fix: 태그 검색 시 자동완성 UI에 포커싱되어 검색창의 포커싱이 풀리는 버그 수정
- 자동완성 UI에 걸어주었던 이벤트를 window 이벤트로 변경하였습니다. 더불어 자동완성 UI에 자동으로 포커싱되게 걸어두었던 로직을 제거하였습니다.
- 서버에서 내려주는 response 데이터 타입을 정의하고 타입에 맞게 tags prop을 다시 설정하였습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

# 📍 기타 (선택)

> 다른 분들이 참고해야할 사항이 있다면 작성해주세요

close #60
