### PR TITLE
[#63] Feat: masonry layout component 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lucide-react": "^0.330.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-masonry-css": "^1.0.16",
     "react-toastify": "^10.0.4",
     "tailwind-merge": "^2.2.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
+  react-masonry-css:
+    specifier: ^1.0.16
+    version: 1.0.16(react@18.2.0)
   react-toastify:
     specifier: ^10.0.4
     version: 10.0.4(react-dom@18.2.0)(react@18.2.0)
@@ -3983,6 +3986,14 @@ packages:
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: true
+
+  /react-masonry-css@1.0.16(react@18.2.0):
+    resolution: {integrity: sha512-KSW0hR2VQmltt/qAa3eXOctQDyOu7+ZBevtKgpNDSzT7k5LA/0XntNa9z9HKCdz3QlxmJHglTZ18e4sX4V8zZQ==}
+    peerDependencies:
+      react: '>=16.0.0'
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /react-refresh@0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}

--- a/src/components/common/MasonryLayout.tsx
+++ b/src/components/common/MasonryLayout.tsx
@@ -1,0 +1,36 @@
+import { ReactNode } from "react";
+import Masonry from "react-masonry-css";
+import { cn } from "@/utils/tailwind";
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+  columnClassName?: string;
+  breakpointColumns?: { [key: string]: number };
+}
+
+const defaultBreakpoint = {
+  default: 4,
+  1220: 3,
+  920: 2,
+  620: 1,
+};
+
+const MasonryLayout = ({
+  children,
+  className,
+  columnClassName,
+  breakpointColumns = defaultBreakpoint,
+}: Props) => {
+  return (
+    <Masonry
+      breakpointCols={breakpointColumns}
+      className={cn("mx-auto flex max-w-screen-xl", className)}
+      columnClassName={cn("flex justify-center h-fit flex-wrap", columnClassName)}
+    >
+      {children}
+    </Masonry>
+  );
+};
+
+export default MasonryLayout;

--- a/src/routes/my-liked-zzal/index.tsx
+++ b/src/routes/my-liked-zzal/index.tsx
@@ -4,6 +4,7 @@ import Pending from "./MyLikedZzal.pendingComponent";
 import useGetMyLikedZzals from "@/hooks/api/zzal/useGetMyLikedZzals";
 import ZzalCard from "@/components/common/ZzalCard";
 import useIntersectionObserver from "@/hooks/common/useIntersectionObserver";
+import MasonryLayout from "@/components/common/MasonryLayout";
 
 const MyLikedZzal = () => {
   const fetchMoreRef = useRef(null);
@@ -17,14 +18,12 @@ const MyLikedZzal = () => {
   return (
     <div className="p-4 text-center">
       <h1 className="mb-4 text-2xl font-bold">좋아요 한 짤 페이지</h1>
-      <div className="mx-auto sm:max-w-620pxr sm:columns-2 md:max-w-920pxr md:columns-3 lg:max-w-1220pxr lg:columns-4">
+      <MasonryLayout>
         {zzals.map(({ imageId, path, title }) => (
-          <div key={imageId} className="mb-4 inline-block break-inside-avoid">
-            <ZzalCard src={path} alt={title} />
-          </div>
+          <ZzalCard key={imageId} src={path} alt={title} />
         ))}
-        <div ref={fetchMoreRef} />
-      </div>
+      </MasonryLayout>
+      <div ref={fetchMoreRef} />
     </div>
   );
 };


### PR DESCRIPTION
## 📝 작업 내용

tailwind의 column을 사용하여 레이아웃을 잡을 수 있으나, 무한 스크롤로 데이터가 추가될때 이미 배열된 이미지의 순서가 변경되는
이슈가 있었습니다.
css만으로는 해결이 어려워 `react-masonry-css`를 활용했습니다.


close #63
