### PR TITLE
[#83] Feat: 좋아요한 짤 페이지에서 태그 추천 api 구현 및 적용

### DIFF
--- a/src/apis/tag.ts
+++ b/src/apis/tag.ts
@@ -1,5 +1,5 @@
 import http from "@/apis/core";
-import { GetTagsResponse, GetTopTagsFromLiked } from "@/types/tag.dto";
+import { GetTagsResponse, GetTopTagsFromLikedResponse } from "@/types/tag.dto";
 
 export const getSearchTag = (tag: string) =>
   http.get<GetTagsResponse>({
@@ -10,6 +10,6 @@ export const getSearchTag = (tag: string) =>
   });
 
 export const getTopTagsFromLiked = () =>
-  http.get<GetTopTagsFromLiked>({
+  http.get<GetTopTagsFromLikedResponse>({
     url: "/v1/tag/me/like",
   });

--- a/src/apis/tag.ts
+++ b/src/apis/tag.ts
@@ -1,5 +1,5 @@
 import http from "@/apis/core";
-import { GetTagsResponse } from "@/types/tag.dto";
+import { GetTagsResponse, GetTopTagsFromLiked } from "@/types/tag.dto";
 
 export const getSearchTag = (tag: string) =>
   http.get<GetTagsResponse>({
@@ -7,4 +7,9 @@ export const getSearchTag = (tag: string) =>
     params: {
       keyword: tag,
     },
+  });
+
+export const getTopTagsFromLiked = () =>
+  http.get<GetTopTagsFromLiked>({
+    url: "/v1/tag/me/like",
   });

--- a/src/apis/zzal.ts
+++ b/src/apis/zzal.ts
@@ -1,7 +1,8 @@
 import { GetMyLikedZzalsResponse } from "@/types/zzal.dto";
 import http from "./core";
-
-const SIZE = 10;
+import { PAGINATION_LIMIT } from "@/constants/api";
 
 export const getMyLikedZzals = (offset: number) =>
-  http.get<GetMyLikedZzalsResponse>({ url: `v1/image/like?page=${offset}&size=${SIZE}` });
+  http.get<GetMyLikedZzalsResponse>({
+    url: `/v1/image/like?page=${offset}&size=${PAGINATION_LIMIT}`,
+  });

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,1 +1,1 @@
-export const PAGINATION_LIMIT = 10;
+export const PAGINATION_LIMIT = 15;

--- a/src/hooks/api/tag/useGetTopTagsFromLiked.ts
+++ b/src/hooks/api/tag/useGetTopTagsFromLiked.ts
@@ -1,0 +1,15 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getTopTagsFromLiked } from "@/apis/tag";
+
+const useGetTopTagsFromLiked = () => {
+  const { data, ...rest } = useSuspenseQuery({
+    queryKey: ["topTagsFromLiked"],
+    queryFn: getTopTagsFromLiked,
+  });
+
+  return {
+    topTags: data,
+    ...rest,
+  };
+};
+export default useGetTopTagsFromLiked;

--- a/src/routes/_layout-with-chat/my-liked-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-liked-zzals/route.lazy.tsx
@@ -22,8 +22,8 @@ const MyLikedZzals = () => {
     <div className="flex w-full flex-col items-center">
       <div className="mb-10pxr min-w-650pxr pl-10pxr">
         <div className="mb-8pxr font-semibold">내가 가장 많이 사용한 태그</div>
-        {topTags.map(({ tagName }) => (
-          <TagBadge content={tagName} isClickable className="mr-5pxr" />
+        {topTags.map(({ tagName }, index) => (
+          <TagBadge key={`${index}-${tagName}`} content={tagName} isClickable className="mr-5pxr" />
         ))}
       </div>
       <TagSearchForm />

--- a/src/routes/_layout-with-chat/my-liked-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-liked-zzals/route.lazy.tsx
@@ -27,7 +27,7 @@ const MyLikedZzals = () => {
         ))}
       </div>
       <TagSearchForm />
-      <MasonryLayout>
+      <MasonryLayout className="mt-15pxr">
         {zzals.map(({ imageId, path, title }) => (
           <ZzalCard className="mb-10pxr" key={imageId} src={path} alt={title} />
         ))}

--- a/src/routes/_layout-with-chat/my-liked-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-liked-zzals/route.lazy.tsx
@@ -1,12 +1,16 @@
 import { useRef } from "react";
 import { createLazyFileRoute } from "@tanstack/react-router";
 import useGetMyLikedZzals from "@/hooks/api/zzal/useGetMyLikedZzals";
-import ZzalCard from "@/components/common/ZzalCard";
+import useGetTopTagsFromLiked from "@/hooks/api/tag/useGetTopTagsFromLiked";
 import useIntersectionObserver from "@/hooks/common/useIntersectionObserver";
+import ZzalCard from "@/components/common/ZzalCard";
 import MasonryLayout from "@/components/common/MasonryLayout";
+import TagBadge from "@/components/common/TagBadge";
+import TagSearchForm from "@/components/common/SearchTag/TagSearchForm";
 
 const MyLikedZzals = () => {
   const fetchMoreRef = useRef(null);
+  const { topTags } = useGetTopTagsFromLiked();
   const { zzals, handleFetchNextPage } = useGetMyLikedZzals();
 
   useIntersectionObserver({
@@ -15,8 +19,14 @@ const MyLikedZzals = () => {
   });
 
   return (
-    <div className="p-4 text-center">
-      <h1 className="mb-4 text-2xl font-bold">좋아요 한 짤 페이지</h1>
+    <div className="flex w-full flex-col items-center">
+      <div className="mb-10pxr min-w-650pxr pl-10pxr">
+        <div className="mb-8pxr font-semibold">내가 가장 많이 사용한 태그</div>
+        {topTags.map(({ tagName }) => (
+          <TagBadge content={tagName} isClickable className="mr-5pxr" />
+        ))}
+      </div>
+      <TagSearchForm />
       <MasonryLayout>
         {zzals.map(({ imageId, path, title }) => (
           <ZzalCard className="mb-10pxr" key={imageId} src={path} alt={title} />

--- a/src/types/tag.dto.ts
+++ b/src/types/tag.dto.ts
@@ -1,3 +1,5 @@
 import { Tag } from "./tag";
 
 export type GetTagsResponse = Tag[];
+
+export type GetTopTagsFromLiked = Tag[];

--- a/src/types/tag.dto.ts
+++ b/src/types/tag.dto.ts
@@ -2,4 +2,4 @@ import { Tag } from "./tag";
 
 export type GetTagsResponse = Tag[];
 
-export type GetTopTagsFromLiked = Tag[];
+export type GetTopTagsFromLikedResponse = Tag[];


### PR DESCRIPTION
## 📝 작업 내용

1. 추천 태그 get api 함수와 커스텀 훅 구현
2. `my-liked-zzal` 페이지 이름을 `my-liked-zzals`로 수정
3. 구현한 커스텀 훅 구현

간단한 get api 함수를 구현하고 적용했습니다~ 페이지 이름은 내가 좋아요한 `짤들`로 복수형이 적절한 것 같아 수정했습니다!


close #83
