### PR TITLE
[#91] Feat: 다운로드 짤 util 함수 구현

### DIFF
--- a/src/utils/downloadZzal.ts
+++ b/src/utils/downloadZzal.ts
@@ -1,0 +1,32 @@
+import { toast } from "react-toastify";
+import axios from "axios";
+
+interface Props {
+  imageUrl: string;
+  imageTitle: string;
+}
+
+const downloadZzal = ({ imageUrl, imageTitle }: Props) => {
+  axios
+    .get(imageUrl, {
+      responseType: "blob",
+      headers: { "Cache-Control": "no-cache" },
+    })
+    .then((response) => {
+      const file = new File([response.data], "file.jpg", { type: "image/jpeg" });
+      const downloadLink = document.createElement("a");
+
+      downloadLink.href = URL.createObjectURL(file);
+      downloadLink.download = `${imageTitle}.jpg`;
+      document.body.appendChild(downloadLink);
+      downloadLink.click();
+      document.body.removeChild(downloadLink);
+      toast.success("성공적으로 다운로드 되었습니다");
+    })
+    .catch((error) => {
+      toast.error("다운로드에 실패했습니다.");
+      console.error("파일 다운로드 중 오류가 발생했습니다:", error);
+    });
+};
+
+export default downloadZzal;

--- a/src/utils/zzalUtils.ts
+++ b/src/utils/zzalUtils.ts
@@ -1,14 +1,14 @@
 import { toast } from "react-toastify";
 import axios from "axios";
 
-interface Props {
+interface DownloadZzalParameters {
   imageUrl: string;
   imageTitle: string;
 }
 
-const downloadZzal = ({ imageUrl, imageTitle }: Props) => {
+export const downloadZzal = ({ imageUrl, imageTitle }: DownloadZzalParameters) => {
   axios
-    .get(imageUrl, {
+    .get<BlobPart>(imageUrl, {
       responseType: "blob",
       headers: { "Cache-Control": "no-cache" },
     })
@@ -28,5 +28,3 @@ const downloadZzal = ({ imageUrl, imageTitle }: Props) => {
       console.error("파일 다운로드 중 오류가 발생했습니다:", error);
     });
 };
-
-export default downloadZzal;


### PR DESCRIPTION
## 📝 작업 내용

> 이미지 상세 보기 모달에 있는 다운로드 함수를 구현했습니다. 
downloadZzal 함수는 이미지 URL과 이미지 제목을 받아서 해당 이미지를 다운로드합니다. 
비동기로 Axios를 사용하여 이미지 데이터를 받아와서 Blob 형태로 변환하고, 
그것을 파일로 생성하여 브라우저에서 다운로드할 수 있도록 처리할 수 있도록 했습니다.

이미지 상세 모달 UI가 아직 머지가 안돼서 젹용은 추후에 진행할 것 같습니다. 

test는 layout-with-chat> index파일에 다음과 같이 버튼을 추가해주시면 될 것 같습니다.
```
import { createFileRoute } from "@tanstack/react-router";
import downloadZzal from "@/utils/downloadZzal";
import { debounce } from "@/utils/debounce";

const Home = () => {
  const handleDownloadClick = debounce(() => {
    downloadZzal({
      imageUrl:
        "https://zzalmyu-bucket.s3.ap-northeast-2.amazonaws.com/upload/keroro9073%40gmail.comtemp_image1626418983561547350.jpg",
      imageTitle: "안유진",
    });
  }, 500);

  return (
    <div>
      <button onClick={handleDownloadClick}>다운로드 test 버튼</button>
    </div>
  );
};

export const Route = createFileRoute("/_layout-with-chat/")({
  component: Home,
});
```

## 💬 리뷰 요구사항(선택)
downloadZzal  파일 위치가 적절한지 궁금합니다.
이미지 상세모달에만 사용되고 재활용되지 않으니까 ImageDetailModal안에 파일 정의하는 해야할까요🧐


close #91 
