### PR TITLE
[#92] Chore: router type 선언 및 devtools 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   "devDependencies": {
     "@commitlint/cli": "^18.6.0",
     "@commitlint/config-conventional": "^18.6.0",
+    "@tanstack/react-query-devtools": "^5.24.7",
+    "@tanstack/router-devtools": "^1.18.3",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,12 @@ devDependencies:
   '@commitlint/config-conventional':
     specifier: ^18.6.0
     version: 18.6.0
+  '@tanstack/react-query-devtools':
+    specifier: ^5.24.7
+    version: 5.24.7(@tanstack/react-query@5.18.1)(react@18.2.0)
+  '@tanstack/router-devtools':
+    specifier: ^1.18.3
+    version: 1.18.3(csstype@3.1.3)(react-dom@18.2.0)(react@18.2.0)
   '@types/react':
     specifier: ^18.2.43
     version: 18.2.55
@@ -330,7 +336,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
-    dev: false
 
   /@babel/template@7.23.9:
     resolution: {integrity: sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==}
@@ -1118,11 +1123,24 @@ packages:
   /@tanstack/history@1.15.13:
     resolution: {integrity: sha512-ToaeMtK5S4YaxCywAlYexc7KPFN0esjyTZ4vXzJhXEWAkro9iHgh7m/4ozPJb7oTo65WkHWX0W9GjcZbInSD8w==}
     engines: {node: '>=12'}
-    dev: false
 
   /@tanstack/query-core@5.18.1:
     resolution: {integrity: sha512-fYhrG7bHgSNbnkIJF2R4VUXb4lF7EBiQjKkDc5wOlB7usdQOIN4LxxHpDxyE3qjqIst1WBGvDtL48T0sHJGKCw==}
-    dev: false
+
+  /@tanstack/query-devtools@5.24.0:
+    resolution: {integrity: sha512-pThim455t69zrZaQKa7IRkEIK8UBTS+gHVAdNfhO72Xh4rWpMc63ovRje5/n6iw63+d6QiJzVadsJVdPoodSeQ==}
+    dev: true
+
+  /@tanstack/react-query-devtools@5.24.7(@tanstack/react-query@5.18.1)(react@18.2.0):
+    resolution: {integrity: sha512-aNh9bGtHSNedpcc/WVxporY0ZLqO4fx7PLOFmhtP5PcHbvtuQlG6q8s2By8Juk/BqXJWGz9FhDHrRjepcQjqQQ==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.24.7
+      react: ^18.0.0
+    dependencies:
+      '@tanstack/query-devtools': 5.24.0
+      '@tanstack/react-query': 5.18.1(react@18.2.0)
+      react: 18.2.0
+    dev: true
 
   /@tanstack/react-query@5.18.1(react@18.2.0):
     resolution: {integrity: sha512-PdI07BbsahZ+04PxSuDQsQvBWe008eWFk/YYWzt8fvzt2sALUM0TpAJa/DFpqa7+SSo7j1EQR6Jx6znXNHyaXw==}
@@ -1131,7 +1149,6 @@ packages:
     dependencies:
       '@tanstack/query-core': 5.18.1
       react: 18.2.0
-    dev: false
 
   /@tanstack/react-router@1.15.22(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-YtG0bMFtviiYJ3bjhUX8AqWYdRXgIsQq+9NpMeSfeTZ3IYs1RZgs1rHJswrOIg/7r5i+L7+6ojzg8AbXqy18cA==}
@@ -1148,6 +1165,21 @@ packages:
       tiny-warning: 1.0.3
     dev: false
 
+  /@tanstack/react-router@1.18.3(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-SaP3myClq8VLrIy+ZCQb+azRa55quWeKVCyjbRZUfNWS0mzRRWkCeNfWBb8M9dYimTLeGHck8GthZDuQBiBkbw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      '@tanstack/history': 1.15.13
+      '@tanstack/react-store': 0.2.1(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tiny-invariant: 1.3.1
+      tiny-warning: 1.0.3
+    dev: true
+
   /@tanstack/react-store@0.2.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-tEbMCQjbeVw9KOP/202LfqZMSNAVi6zYkkp1kBom8nFuMx/965Hzes3+6G6b/comCwVxoJU8Gg9IrcF8yRPthw==}
     peerDependencies:
@@ -1158,7 +1190,23 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       use-sync-external-store: 1.2.0(react@18.2.0)
-    dev: false
+
+  /@tanstack/router-devtools@1.18.3(csstype@3.1.3)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-mB/2DQcaAiP2GxzfSa8ssBq7FjbsJ8LzfiLYlO9VQSODe/zI0gEdR04OOSJkMwo7oeigxxAlSBVRvBZ4RZyQRA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      '@tanstack/react-router': 1.18.3(react-dom@18.2.0)(react@18.2.0)
+      clsx: 2.1.0
+      date-fns: 2.30.0
+      goober: 2.1.14(csstype@3.1.3)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - csstype
+    dev: true
 
   /@tanstack/router-generator@1.15.22:
     resolution: {integrity: sha512-E3yDWSTt2pH05rV4QZF3ghlzqWEPjo9iKWDxSfKEQUPripxYEduhguAaybzbbB+XKN0BdvQq+08yl/lQg7Tc3Q==}
@@ -1177,7 +1225,6 @@ packages:
 
   /@tanstack/store@0.1.3:
     resolution: {integrity: sha512-GnolmC8Fr4mvsHE1fGQmR3Nm0eBO3KnZjDU0a+P3TeQNM/dDscFGxtA7p31NplQNW3KwBw4t1RVFmz0VeKLxcw==}
-    dev: false
 
   /@toss/use-overlay@1.3.8(react@18.2.0):
     resolution: {integrity: sha512-VdyAOaZsiDN5I+eo3oNZVOTqDU+S+WL+xg7Qln/ea073JO7l+UVnv4GWkRTCsmF1GB0OI4WBDDi0U7XEkLt0nQ==}
@@ -1800,7 +1847,6 @@ packages:
   /clsx@2.1.0:
     resolution: {integrity: sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==}
     engines: {node: '>=6'}
-    dev: false
 
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -1959,6 +2005,13 @@ packages:
   /dargs@7.0.0:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
     engines: {node: '>=8'}
+    dev: true
+
+  /date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+    engines: {node: '>=0.11'}
+    dependencies:
+      '@babel/runtime': 7.23.9
     dev: true
 
   /debug@3.2.7:
@@ -2821,6 +2874,14 @@ packages:
       ignore: 5.3.1
       merge2: 1.4.1
       slash: 3.0.0
+    dev: true
+
+  /goober@2.1.14(csstype@3.1.3):
+    resolution: {integrity: sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==}
+    peerDependencies:
+      csstype: ^3.0.10
+    dependencies:
+      csstype: 3.1.3
     dev: true
 
   /gopd@1.0.1:
@@ -4021,7 +4082,6 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
-    dev: false
 
   /react-error-boundary@4.0.12(react@18.2.0):
     resolution: {integrity: sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==}
@@ -4057,7 +4117,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-    dev: false
 
   /read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
@@ -4123,7 +4182,6 @@ packages:
 
   /regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
-    dev: false
 
   /regexp.prototype.flags@1.5.1:
     resolution: {integrity: sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==}
@@ -4259,7 +4317,6 @@ packages:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
     dependencies:
       loose-envify: 1.4.0
-    dev: false
 
   /semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -4639,11 +4696,9 @@ packages:
 
   /tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
-    dev: false
 
   /tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
-    dev: false
 
   /to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -4800,7 +4855,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.2.0
-    dev: false
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { OverlayProvider } from "@toss/use-overlay";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { TanStackRouterDevtools } from "@tanstack/router-devtools";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
 import { routeTree } from "./routeTree.gen";
 
 const router = createRouter({
@@ -24,8 +23,6 @@ const App = () => {
       <OverlayProvider>
         <RouterProvider router={router} />
       </OverlayProvider>
-      <ReactQueryDevtools buttonPosition="top-right" />
-      <TanStackRouterDevtools position="bottom-right" />
     </QueryClientProvider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,20 @@
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { OverlayProvider } from "@toss/use-overlay";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TanStackRouterDevtools } from "@tanstack/router-devtools";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { routeTree } from "./routeTree.gen";
 
 const router = createRouter({
   routeTree,
   defaultPreload: "intent",
 });
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}
 
 const queryClient = new QueryClient();
 
@@ -16,6 +24,8 @@ const App = () => {
       <OverlayProvider>
         <RouterProvider router={router} />
       </OverlayProvider>
+      <ReactQueryDevtools buttonPosition="top-right" />
+      <TanStackRouterDevtools position="bottom-right" />
     </QueryClientProvider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { OverlayProvider } from "@toss/use-overlay";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-
 import { routeTree } from "./routeTree.gen";
 
 const router = createRouter({

--- a/src/components/AdminReports/ReportsTableBody .tsx
+++ b/src/components/AdminReports/ReportsTableBody .tsx
@@ -16,7 +16,7 @@ const ReportsTableBody = ({ reports }: Props) => {
             <td className="text-center text-text-primary">{imageTitle}</td>
             <td className="text-center text-text-primary">{reportCount}</td>
             <td className="text-center text-text-primary">
-              <Link to={`/admin/reports/${imageId}`}>
+              <Link to="/admin/reports/$imageId" params={{ imageId: String(imageId) }}>
                 <button className="btn btn-neutral btn-sm text-xs">상세보기</button>
               </Link>
             </td>

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -19,7 +19,7 @@ const Header = () => {
       <div className="flex flex-1 items-center justify-end space-x-3 px-2">
         <ThemeToggle />
         {user && !user.isAdmin && (
-          <Link to="/upload-zzal/">
+          <Link to="/upload-zzal">
             <button className="btn h-9 min-h-9 border-primary bg-primary text-white hover:bg-gray-300">
               업로드
             </button>
@@ -28,7 +28,7 @@ const Header = () => {
         <div className="h-6 w-0.5 bg-text-primary"></div>
         {!user && <button className="btn btn-ghost h-6 min-h-9">로그인</button>}
         {user && user.isAdmin && (
-          <Link to="/admin/" className="btn btn-ghost h-6 min-h-9 text-text-primary">
+          <Link to="/admin/reports" className="btn btn-ghost h-6 min-h-9 text-text-primary">
             Admin
           </Link>
         )}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,9 +17,9 @@ import { Route as LayoutWithChatImport } from "./routes/_layout-with-chat"
 import { Route as UploadZzalIndexImport } from "./routes/upload-zzal/index"
 import { Route as LayoutWithChatIndexImport } from "./routes/_layout-with-chat/index"
 import { Route as AdminReportsIndexImport } from "./routes/admin/reports/index"
-import { Route as AdminReportsImageIdIndexImport } from "./routes/admin/reports/$imageId/index"
 import { Route as LayoutWithChatMyUploadedZzalIndexImport } from "./routes/_layout-with-chat/my-uploaded-zzal/index"
 import { Route as LayoutWithChatMyLikedZzalIndexImport } from "./routes/_layout-with-chat/my-liked-zzal/index"
+import { Route as AdminReportsImageIdIndexImport } from "./routes/admin/reports/$imageId/index"
 
 // Create Virtual Routes
 
@@ -49,6 +49,18 @@ const AdminReportsIndexRoute = AdminReportsIndexImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
+const LayoutWithChatMyUploadedZzalIndexRoute =
+  LayoutWithChatMyUploadedZzalIndexImport.update({
+    path: "/my-uploaded-zzal/",
+    getParentRoute: () => LayoutWithChatRoute,
+  } as any)
+
+const LayoutWithChatMyLikedZzalIndexRoute =
+  LayoutWithChatMyLikedZzalIndexImport.update({
+    path: "/my-liked-zzal/",
+    getParentRoute: () => LayoutWithChatRoute,
+  } as any)
+
 const AdminReportsAdminReportsPendingComponentRoute =
   AdminReportsAdminReportsPendingComponentImport.update({
     path: "/admin/reports/AdminReports",
@@ -64,18 +76,6 @@ const AdminReportsImageIdIndexRoute = AdminReportsImageIdIndexImport.update({
   path: "/admin/reports/$imageId/",
   getParentRoute: () => rootRoute,
 } as any)
-
-const LayoutWithChatMyUploadedZzalIndexRoute =
-  LayoutWithChatMyUploadedZzalIndexImport.update({
-    path: "/my-uploaded-zzal/",
-    getParentRoute: () => LayoutWithChatRoute,
-  } as any)
-
-const LayoutWithChatMyLikedZzalIndexRoute =
-  LayoutWithChatMyLikedZzalIndexImport.update({
-    path: "/my-liked-zzal/",
-    getParentRoute: () => LayoutWithChatRoute,
-  } as any)
 
 // Populate the FileRoutesByPath interface
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,6 +1,8 @@
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { Outlet, createRootRoute } from "@tanstack/react-router";
+import { TanStackRouterDevtools } from "@tanstack/router-devtools";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import NotFound from "./-NotFound";
 import Header from "@/components/common/Header";
 
@@ -12,6 +14,8 @@ const RootComponent = () => {
         <Outlet />
       </div>
       <ToastContainer />
+      <ReactQueryDevtools buttonPosition="top-right" />
+      <TanStackRouterDevtools position="bottom-right" />
     </div>
   );
 };

--- a/src/routes/_layout-with-chat.tsx
+++ b/src/routes/_layout-with-chat.tsx
@@ -1,4 +1,6 @@
 import { Outlet, createFileRoute } from "@tanstack/react-router";
+import { TanStackRouterDevtools } from "@tanstack/router-devtools";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import Chat from "@/components/common/Chat";
 
 const LayoutWithChat = () => {
@@ -8,6 +10,8 @@ const LayoutWithChat = () => {
         <Outlet />
       </div>
       <Chat />
+      <ReactQueryDevtools buttonPosition="top-right" />
+      <TanStackRouterDevtools position="bottom-right" />
     </div>
   );
 };

--- a/src/routes/admin/reports/$imageId/index.tsx
+++ b/src/routes/admin/reports/$imageId/index.tsx
@@ -37,7 +37,7 @@ const AdminImageDetail = () => {
         <div className="breadcrumbs pb-20pxr text-lg font-bold">
           <ul>
             <li>
-              <Link to="/admin/reports/">
+              <Link to="/admin/reports">
                 <h1>신고 내역</h1>
               </Link>
             </li>


### PR DESCRIPTION
## 📝 작업 내용

Link, navigate의 path 타입을 추론할 수 있도록 router type 선언해주었습니다. Link 작성시 아래처럼 자동완성이 됩니다.
<img width="558" alt="스크린샷 2024-03-04 오후 12 22 13" src="https://github.com/zzalmyu/zzalmyu-frontend/assets/61978339/56135aa0-d753-440d-a28c-f9317a839cb5">

react query devtools와 tanstack router devtools를 설치하고 적용했습니다.

+) Link 타입을 적용하면서 타입이 맞지 않는 것들을 타입에 맞도록 수정해주었습니다.

close #92
