### PR TITLE
[#98] Feat: 복사 짤 util 함수 구현

### DIFF
--- a/src/routes/_layout-with-chat/index.tsx
+++ b/src/routes/_layout-with-chat/index.tsx
@@ -1,7 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { copyZzal } from "@/utils/copyZzal";
+import { debounce } from "@/utils/debounce";
 
 const Home = () => {
-  return <div></div>;
+  const handleCopyClick = debounce(() => {
+    copyZzal(
+      "https://zzalmyu-bucket.s3.ap-northeast-2.amazonaws.com/upload/keroro9073%40gmail.comtemp_image10005225818988034545.jpg",
+    );
+  }, 500);
+
+  return (
+    <div>
+      <button onClick={handleCopyClick}>복사 test 버튼</button>
+    </div>
+  );
 };
 
 export const Route = createFileRoute("/_layout-with-chat/")({

--- a/src/routes/_layout-with-chat/index.tsx
+++ b/src/routes/_layout-with-chat/index.tsx
@@ -1,19 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { copyZzal } from "@/utils/copyZzal";
-import { debounce } from "@/utils/debounce";
 
 const Home = () => {
-  const handleCopyClick = debounce(() => {
-    copyZzal(
-      "https://zzalmyu-bucket.s3.ap-northeast-2.amazonaws.com/upload/keroro9073%40gmail.comtemp_image10005225818988034545.jpg",
-    );
-  }, 500);
-
-  return (
-    <div>
-      <button onClick={handleCopyClick}>복사 test 버튼</button>
-    </div>
-  );
+  return <div></div>;
 };
 
 export const Route = createFileRoute("/_layout-with-chat/")({

--- a/src/utils/copyZzal.ts
+++ b/src/utils/copyZzal.ts
@@ -1,0 +1,66 @@
+import { toast } from "react-toastify";
+import axios from "axios";
+
+const createImage = (src: string) => {
+  const image = document.createElement("img");
+  image.src = src;
+  return image;
+};
+
+const copyToClipboard = async (pngBlob: Blob) => {
+  try {
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        [pngBlob.type]: pngBlob,
+      }),
+    ]);
+    toast.success("성공적으로 복사되었습니다.");
+  } catch (error) {
+    toast.error("복사에 실패했습니다.");
+    console.error(error);
+  }
+};
+
+const copyJpgToClipboard = (imgBlob: Blob) => {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  const image = createImage(window.URL.createObjectURL(imgBlob));
+  image.onload = (event) => {
+    if (event && event.target) {
+      const target = event.target as HTMLImageElement;
+      canvas.width = target.width;
+      canvas.height = target.height;
+      if (ctx) {
+        ctx.drawImage(target, 0, 0, target.width, target.height);
+        canvas.toBlob(
+          (blob) => {
+            if (blob) {
+              copyToClipboard(blob);
+            }
+          },
+          "image/png",
+          1,
+        );
+      }
+    }
+  };
+};
+
+const copyZzal = async (imageUrl: string) => {
+  try {
+    const imgResponse = await axios.get(imageUrl, { responseType: "blob" });
+    const imgBlob = imgResponse.data;
+    const extension = imageUrl.split(".").pop()?.toLowerCase();
+
+    if (extension === "jpg") {
+      copyJpgToClipboard(imgBlob);
+    } else {
+      console.error("예상치 못한 파일 형식입니다: " + extension);
+    }
+  } catch (error) {
+    toast.error("복사에 실패했습니다.");
+    console.error(error);
+  }
+};
+
+export default copyZzal;

--- a/src/utils/copyZzal.ts
+++ b/src/utils/copyZzal.ts
@@ -48,7 +48,7 @@ const copyJpgToClipboard = (imgBlob: Blob) => {
 
 export const copyZzal = async (imageUrl: string) => {
   try {
-    const imgResponse = await axios.get(imageUrl, { responseType: "blob" });
+    const imgResponse = await axios.get<Blob>(imageUrl, { responseType: "blob" });
     const imgBlob = imgResponse.data;
     const extension = imageUrl.split(".").pop()?.toLowerCase();
 

--- a/src/utils/copyZzal.ts
+++ b/src/utils/copyZzal.ts
@@ -46,7 +46,7 @@ const copyJpgToClipboard = (imgBlob: Blob) => {
   };
 };
 
-const copyZzal = async (imageUrl: string) => {
+export const copyZzal = async (imageUrl: string) => {
   try {
     const imgResponse = await axios.get(imageUrl, { responseType: "blob" });
     const imgBlob = imgResponse.data;
@@ -62,5 +62,3 @@ const copyZzal = async (imageUrl: string) => {
     console.error(error);
   }
 };
-
-export default copyZzal;


### PR DESCRIPTION
## 📝 작업 내용

이미지 상세 모달 api 코드는 어느정도 완료한 상태인데 ui 머지 후 진행하는게 좋을 것 같아 
이미지 복사 기능 함수를 구현했습니다. 

> 이미지를 복사하여 클립보드에 저장합니다.
navigator.clipboard.write(data)를 사용합니다. 

> 클립보드 API에서 제공하는 데이터 형식은 text, html, png 이미지 데이터로 제한되어있습니다.
따라서 서버에 있는 `jpg`파일을 `png`로 변환하는 로직을 추가했습니다.
파일 변환은 `jpg `이미지를 `<canvas>` 요소에 그려서 `png`이미지로 변환합니다.

test는 layout-with-chat> index파일에 다음과 같이 버튼을 추가해주시면 될 것 같습니다:)
```
import { createFileRoute } from "@tanstack/react-router";
import copyZzal from "@/utils/copyZzal";
import { debounce } from "@/utils/debounce";

const Home = () => {
  const handleCopyClick = debounce(() => {
    copyZzal(
      "https://zzalmyu-bucket.s3.ap-northeast-2.amazonaws.com/upload/keroro9073%40gmail.comtemp_image10005225818988034545.jpg",
    );
  }, 500);

  return (
    <div>
      <button onClick={handleCopyClick}>복사 test 버튼</button>
    </div>
  );
};

export const Route = createFileRoute("/_layout-with-chat/")({
  component: Home,
});
```


# 📍 기타 (선택)
[MDN문서 : Clipboard: write() method](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/write)
[stackoverflow : how to copy an image to clipboard?](https://stackoverflow.com/questions/59182747/react-how-to-copy-an-image-to-clipboard)
close #98 
