### PR TITLE
[#110] Feat: 로그아웃 기능 구현

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,11 @@
+import { getLocalStorage } from "@/utils/localStorage";
+import http from "./core";
+import { REFRESH_TOKEN } from "@/constants/auth";
+
+export const patchLogOut = () =>
+  http.patch<void>({
+    headers: {
+      "Authorization-refresh": `Bearer ${getLocalStorage(REFRESH_TOKEN)}`,
+    },
+    url: "/v1/user/logout",
+  });

--- a/src/components/common/Header/DropdownMenu.tsx
+++ b/src/components/common/Header/DropdownMenu.tsx
@@ -1,6 +1,11 @@
 import { useRef } from "react";
-import { Home, Heart, FolderUp, LogOut } from "lucide-react";
+import { Home, Heart, FolderUp, LogOut, LogIn } from "lucide-react";
 import { Link } from "@tanstack/react-router";
+import { useOverlay } from "@toss/use-overlay";
+import LoginModal from "@/components/LoginModal";
+import { getLocalStorage } from "@/utils/localStorage";
+import { REFRESH_TOKEN } from "@/constants/auth";
+import useLogout from "@/hooks/api/auth/useLogout";
 
 interface Props {
   user: {
@@ -9,6 +14,18 @@ interface Props {
 }
 
 const DropdownMenu = ({ user }: Props) => {
+  const loginModalOverlay = useOverlay();
+  const refreshToken = getLocalStorage(REFRESH_TOKEN);
+  const { logout } = useLogout();
+
+  const handleClickLogin = () => {
+    loginModalOverlay.open(({ isOpen, close }) => <LoginModal isOpen={isOpen} onClose={close} />);
+  };
+
+  const handleClickLogout = () => {
+    logout();
+  };
+
   const menuItems = [
     {
       path: "/my-uploaded-zzal/",
@@ -27,8 +44,9 @@ const DropdownMenu = ({ user }: Props) => {
     },
     {
       path: "/",
-      Icon: LogOut,
-      name: "로그아웃",
+      Icon: refreshToken ? LogOut : LogIn,
+      name: refreshToken ? "로그아웃" : "로그인",
+      onClick: refreshToken ? handleClickLogout : handleClickLogin,
     },
   ];
 
@@ -48,8 +66,8 @@ const DropdownMenu = ({ user }: Props) => {
             {user.name}
           </summary>
           <ul className="right-1 z-[1] w-44 rounded-box bg-background text-text-primary ">
-            {menuItems.map(({ path, Icon, name }, index) => (
-              <li key={`${index}-${name}`} className="group" onClick={toggleDetails}>
+            {menuItems.map(({ path, Icon, name, onClick }, index) => (
+              <li key={`${index}-${name}`} className="group" onClick={onClick || toggleDetails}>
                 <Link
                   to={path}
                   className="[&.active]:text-white "

--- a/src/components/common/Header/DropdownMenu.tsx
+++ b/src/components/common/Header/DropdownMenu.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import { Home, Heart, FolderUp, LogOut, LogIn } from "lucide-react";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { useOverlay } from "@toss/use-overlay";
 import LoginModal from "@/components/LoginModal";
 import { getLocalStorage } from "@/utils/localStorage";
@@ -16,6 +16,7 @@ interface Props {
 const DropdownMenu = ({ user }: Props) => {
   const loginModalOverlay = useOverlay();
   const refreshToken = getLocalStorage(REFRESH_TOKEN);
+  const navigate = useNavigate();
   const { logout } = useLogout();
 
   const handleClickLogin = () => {
@@ -23,7 +24,9 @@ const DropdownMenu = ({ user }: Props) => {
   };
 
   const handleClickLogout = () => {
-    logout();
+    logout(undefined, {
+      onSuccess: () => navigate({ to: "/" }),
+    });
   };
 
   const menuItems = [

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,0 +1,2 @@
+export const ACCESS_TOKEN = "accessToken";
+export const REFRESH_TOKEN = "refreshToken";

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -1,23 +1,17 @@
-import { toast } from "react-toastify";
 import { useMutation } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
 import { patchLogOut } from "@/apis/auth";
 import { removeLocalStorage } from "@/utils/localStorage";
 import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/constants/auth";
 
 const useLogout = () => {
-  const navigate = useNavigate();
-
   const { mutate, ...rest } = useMutation({
     mutationFn: patchLogOut,
     onSuccess: () => {
       removeLocalStorage(ACCESS_TOKEN);
       removeLocalStorage(REFRESH_TOKEN);
-      navigate({ to: "/" });
     },
     onError: (error) => {
       console.error(error);
-      toast.error("로그아웃에 실패하였습니다 다시 시도해주세요.");
     },
   });
 

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -1,0 +1,27 @@
+import { toast } from "react-toastify";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { patchLogOut } from "@/apis/auth";
+import { removeLocalStorage } from "@/utils/localStorage";
+import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/constants/auth";
+
+const useLogout = () => {
+  const navigate = useNavigate();
+
+  const { mutate, ...rest } = useMutation({
+    mutationFn: () => patchLogOut(),
+    onSuccess: () => {
+      removeLocalStorage(ACCESS_TOKEN);
+      removeLocalStorage(REFRESH_TOKEN);
+      navigate({ to: "/" });
+    },
+    onError: (error) => {
+      console.log(error);
+      toast.error("로그아웃에 실패하였습니다 다시 시도해주세요.");
+    },
+  });
+
+  return { logout: mutate, ...rest };
+};
+
+export default useLogout;

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -9,7 +9,7 @@ const useLogout = () => {
   const navigate = useNavigate();
 
   const { mutate, ...rest } = useMutation({
-    mutationFn: () => patchLogOut(),
+    mutationFn: patchLogOut,
     onSuccess: () => {
       removeLocalStorage(ACCESS_TOKEN);
       removeLocalStorage(REFRESH_TOKEN);

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -16,7 +16,7 @@ const useLogout = () => {
       navigate({ to: "/" });
     },
     onError: (error) => {
-      console.log(error);
+      console.error(error);
       toast.error("로그아웃에 실패하였습니다 다시 시도해주세요.");
     },
   });


### PR DESCRIPTION
## 📝 작업 내용

> 로그아웃 기능을 구현하였습니다.
- 로그아웃 버튼 클릭 시 로컬 스토리지에 저장되어있는 액세스/리프레시 토큰을 삭제 한 뒤 메인 페이지로 이동시켜주었습니다.
- 드랍 다운 메뉴의 로그인/로그아웃을 토글로 구현하였습니다.

테스트 해보시려면 core.ts의 요청을 가로채는 부분에서 상수로 등록한 `ACCESS_TOKEN`을 `getLocalStorage`에 넣어주시고, #85 의 로그인 모달에 수정된 부분을 현재 PR의 로그인 모달에 넣어주시면 됩니다!

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

# 📍 기타 (선택)

close #110 
