### PR TITLE
[#133] Feat: 짤 신고 시 BE 커스텀 error code에 따라 구분된 신고 Toast 메시지 출력

### DIFF
--- a/src/components/ImageDetailModal/index.tsx
+++ b/src/components/ImageDetailModal/index.tsx
@@ -2,6 +2,7 @@ import { useState, Fragment, Suspense } from "react";
 import { toast } from "react-toastify";
 import { Heart, Copy, FolderDown, SendHorizontal, Siren, Trash2, Hash } from "lucide-react";
 import { useOverlay } from "@toss/use-overlay";
+import axios, { AxiosError } from "axios";
 import { cn } from "@/utils/tailwind";
 import { copyZzal, downloadZzal } from "@/utils/zzalUtils";
 import { debounce } from "@/utils/debounce";
@@ -34,13 +35,27 @@ const ImageDetailModalContent = () => {
   const isUploader = uploadUserId === 19;
   //TODO: [2024.03.01] 추후 실제 사용자 아이디와 비교하기
 
+  const errorMessage = {
+    REPORT_ALREADY_EXIST_ERROR: "이미 신고가 완료되었습니다.",
+    DEFAULT: "신고가 올바르게 되지 않았습니다.",
+  };
+
   const handleClickReportCompeleteButton = (imageId: number) => () => {
     reportZzal(imageId, {
       onSuccess: () => {
         toast.success("신고가 완료되었습니다.");
       },
-      onError: () => {
-        // TODO: [2024-03-06] http error code 별 메세지(ex. 이미 신고가 완료되었습니다) 추가
+      onError: (error: Error | AxiosError) => {
+        if (!axios.isAxiosError(error)) {
+          return;
+        }
+
+        const errorResponse = error.response?.data;
+        const status = errorResponse.statusCode;
+
+        status == "400"
+          ? toast.error(errorMessage["REPORT_ALREADY_EXIST_ERROR"])
+          : toast.error(errorMessage["DEFAULT"]);
       },
     });
   };

--- a/src/components/ImageDetailModal/index.tsx
+++ b/src/components/ImageDetailModal/index.tsx
@@ -55,11 +55,9 @@ const ImageDetailModalContent = () => {
           return;
         }
 
-        const errorResponse = error.response?.data as CustomErrorResponse;
-        const status = errorResponse.statusCode;
-        const code = errorResponse.code;
+        const { statusCode, code } = error.response?.data as CustomErrorResponse;
 
-        if (status === 400 && code === "REPORT_ALREADY_EXIST_ERROR") {
+        if (statusCode === 400 && code === "REPORT_ALREADY_EXIST_ERROR") {
           toast.error(errorMessage[code]);
         } else {
           toast.error(errorMessage["DEFAULT"]);

--- a/src/components/ImageDetailModal/index.tsx
+++ b/src/components/ImageDetailModal/index.tsx
@@ -19,6 +19,11 @@ interface Props {
   onClose: () => void;
 }
 
+interface CustomErrorResponse {
+  statusCode: number;
+  code: string;
+}
+
 const IMAGEID = 70;
 //TODO: [2024.03.06] 실제 IMAGEID 받기
 
@@ -50,12 +55,15 @@ const ImageDetailModalContent = () => {
           return;
         }
 
-        const errorResponse = error.response?.data;
+        const errorResponse = error.response?.data as CustomErrorResponse;
         const status = errorResponse.statusCode;
+        const code = errorResponse.code;
 
-        status == "400"
-          ? toast.error(errorMessage["REPORT_ALREADY_EXIST_ERROR"])
-          : toast.error(errorMessage["DEFAULT"]);
+        if (status === 400 && code === "REPORT_ALREADY_EXIST_ERROR") {
+          toast.error(errorMessage[code]);
+        } else {
+          toast.error(errorMessage["DEFAULT"]);
+        }
       },
     });
   };


### PR DESCRIPTION
## 📝 작업 내용

- AxiosError인지 확인 후, 응답 status에 따라 구분
- BE 커스텀 에러 코드를 이용하여 에러를 구분합니다.
  - 400 에러일 경우 BE 커스텀 error code가 `REPORT_ALREADY_EXIST_ERROR`에 해당하면 -> `이미 신고가 완료되었습니다` 토스트 메시지 
  - 위 경우를 제외한 경우(다른 400 에러, 500 에러 등)는 -> `신고가 올바르게 되지 않았습니다` 토스트 메시지 (`DEFAULT`)

## 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 📍 기타 (선택)

![image](https://github.com/zzalmyu/zzalmyu-frontend/assets/82134668/27213846-3fcf-4640-a51b-29e9adc6d384)

* 참고한 자료입니다.
  - https://github.com/axios/axios/issues/3612 - AxiosError type
  - https://9yujin.tistory.com/59 - 커스텀 에러 핸들링

- 찾아봤을 때는 커스텀 에러 핸들링을 하기 위해서 따로 훅으로 구현하거나, switch로 status를 확인하는 코드들을 확인했는데, 저희는 '중복 신고'의 경우에만 적용해주기 때문에 다음과 같이 구현했습니다

close #133
