### PR TITLE
[#147] Fix: 무한 스크롤 트리거를 위한 div 태그 보이지 않는 스타일 수정

### DIFF
--- a/src/routes/_layout-with-chat.tsx
+++ b/src/routes/_layout-with-chat.tsx
@@ -31,7 +31,7 @@ const LayoutWithChat = () => {
           </button>
         </div>
       </div>
-      <div className="relative flex h-[calc(100%-80px)] w-full overflow-hidden">
+      <div className="relative flex h-[calc(100%-135px)] w-full overflow-hidden">
         <div
           className={cn(
             "h-full overflow-auto border-r border-border px-6 py-4 transition-[width] duration-500 ease-in-out",


### PR DESCRIPTION
## 📝 작업 내용

> 무한 스크롤 트리거를 위한 div 태그 보이지 않는 스타일 수정

Masonry layout을 감싸고 있는 컨테이너의 높이를 재정의 해주었습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

close #147 
