### PR TITLE
[#160] Feat: 업로드한 짤 페이지에 짤 삭제 버튼 추가

### DIFF
--- a/src/hooks/api/zzal/useDeleteMyZzal.ts
+++ b/src/hooks/api/zzal/useDeleteMyZzal.ts
@@ -1,10 +1,16 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deleteMyZzal } from "@/apis/zzal";
 
 const useDeleteMyZzal = () => {
+  const queryClient = useQueryClient();
+
   const { mutate, ...rest } = useMutation({
     mutationFn: deleteMyZzal,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["uploadedZzals"] });
+    },
   });
+
   return { deleteMyZzal: mutate, ...rest };
 };
 

--- a/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
@@ -1,16 +1,17 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { createLazyFileRoute } from "@tanstack/react-router";
+import { useSetAtom } from "jotai";
 import useGetTopTagsFromUploaded from "@/hooks/api/tag/useGetTopTagsFromUploaded";
 import useGetMyUploadedZzals from "@/hooks/api/zzal/useGetMyUploadedZzals";
 import useIntersectionObserver from "@/hooks/common/useIntersectionObserver";
-import TagSearchForm from "@/components/common/SearchTag/TagSearchForm";
-import TagBadge from "@/components/common/TagBadge";
 import MasonryLayout from "@/components/common/MasonryLayout";
 import ZzalCard from "@/components/common/ZzalCard";
+import { $recommendedTags } from "@/store/tag";
 
 const MyUploadedZzals = () => {
   const { topTags } = useGetTopTagsFromUploaded();
   const { zzals, handleFetchNextPage } = useGetMyUploadedZzals();
+  const setRecommendedTags = useSetAtom($recommendedTags);
   const fetchMoreRef = useRef(null);
 
   useIntersectionObserver({
@@ -18,15 +19,12 @@ const MyUploadedZzals = () => {
     handleIntersect: handleFetchNextPage,
   });
 
+  useEffect(() => {
+    setRecommendedTags(topTags);
+  }, [topTags, setRecommendedTags]);
+
   return (
     <div className="flex w-full flex-col items-center">
-      <div className="mb-10pxr min-w-650pxr pl-10pxr">
-        <div className="mb-8pxr font-semibold">내가 가장 많이 사용한 태그</div>
-        {topTags.map(({ tagId, tagName }) => (
-          <TagBadge key={tagId} content={tagName} isClickable className="mr-5pxr" />
-        ))}
-      </div>
-      <TagSearchForm />
       <MasonryLayout className="mt-15pxr">
         {zzals.map(({ imageId, path, title, imageLikeYn }, index) => (
           <ZzalCard

--- a/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
@@ -33,9 +33,17 @@ const MyUploadedZzals = () => {
   return (
     <div className="flex w-full flex-col items-center">
       <MasonryLayout className="mt-15pxr">
-        {zzals.map(({ imageId, path, title }) => (
+        {zzals.map(({ imageId, path, title, imageLikeYn }, index) => (
           <div className="relative" key={imageId}>
-            <ZzalCard className="mb-10pxr" src={path} alt={title} />
+            <ZzalCard
+              className="mb-10pxr"
+              src={path}
+              alt={title}
+              imageId={imageId}
+              imageIndex={index}
+              isLiked={imageLikeYn}
+              queryKey="uploadedZzals"
+            />
             <XCircle
               onClick={handleClickDeleteButton(imageId)}
               className="absolute right-2 top-2 z-0"

--- a/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
@@ -38,7 +38,7 @@ const MyUploadedZzals = () => {
             <ZzalCard className="mb-10pxr" src={path} alt={title} />
             <XCircle
               onClick={handleClickDeleteButton(imageId)}
-              className="absolute right-0 top-0 z-0"
+              className="absolute right-2 top-2 z-0"
               fill="white"
               aria-label="짤 삭제"
             />

--- a/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { createLazyFileRoute } from "@tanstack/react-router";
+import { XCircle } from "lucide-react";
 import { useSetAtom } from "jotai";
 import useGetTopTagsFromUploaded from "@/hooks/api/tag/useGetTopTagsFromUploaded";
 import useGetMyUploadedZzals from "@/hooks/api/zzal/useGetMyUploadedZzals";
@@ -7,10 +8,12 @@ import useIntersectionObserver from "@/hooks/common/useIntersectionObserver";
 import MasonryLayout from "@/components/common/MasonryLayout";
 import ZzalCard from "@/components/common/ZzalCard";
 import { $recommendedTags } from "@/store/tag";
+import useDeleteMyZzal from "@/hooks/api/zzal/useDeleteMyZzal";
 
 const MyUploadedZzals = () => {
   const { topTags } = useGetTopTagsFromUploaded();
   const { zzals, handleFetchNextPage } = useGetMyUploadedZzals();
+  const { deleteMyZzal } = useDeleteMyZzal();
   const setRecommendedTags = useSetAtom($recommendedTags);
   const fetchMoreRef = useRef(null);
 
@@ -23,20 +26,23 @@ const MyUploadedZzals = () => {
     setRecommendedTags(topTags);
   }, [topTags, setRecommendedTags]);
 
+  const handleClickDeleteButton = (imageId: number) => () => {
+    deleteMyZzal(imageId);
+  };
+
   return (
     <div className="flex w-full flex-col items-center">
       <MasonryLayout className="mt-15pxr">
-        {zzals.map(({ imageId, path, title, imageLikeYn }, index) => (
-          <ZzalCard
-            className="mb-10pxr"
-            key={imageId}
-            src={path}
-            alt={title}
-            imageId={imageId}
-            isLiked={imageLikeYn}
-            imageIndex={index}
-            queryKey="likedZzals"
-          />
+        {zzals.map(({ imageId, path, title }) => (
+          <div className="relative" key={imageId}>
+            <ZzalCard className="mb-10pxr" src={path} alt={title} />
+            <XCircle
+              onClick={handleClickDeleteButton(imageId)}
+              className="absolute right-0 top-0 z-0"
+              fill="white"
+              aria-label="짤 삭제"
+            />
+          </div>
         ))}
       </MasonryLayout>
       <div ref={fetchMoreRef} />


### PR DESCRIPTION
## 📝 작업 내용

기존 모든 페이지에서 짤을 삭제할 수 있었는데, 업로드한 짤 페이지에서만 삭제할 수 있도록 수정
업로드한 짤 페이지에서만 삭제할 수 있을 경우, 호버했을때 삭제 버튼이 보이는 것보다 명시적으로 삭제 버튼이 보여야 한다고 생각해, 삭제 버튼을 추가했습니다.

디자인은 추후 수정해보도록 하겠습니다!

close #160
