### PR TITLE
[#136] Feat: 짤 상세 모달에서 삭제 버튼 제거

### DIFF
--- a/src/components/ImageDetailModal/ButtonWithIcon.tsx
+++ b/src/components/ImageDetailModal/ButtonWithIcon.tsx
@@ -11,6 +11,7 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   onClick: () => void;
   isDisabled?: boolean;
   isLoading?: boolean;
+  className?: string;
 }
 
 const ButtonWithIcon = ({
@@ -20,6 +21,7 @@ const ButtonWithIcon = ({
   onClick,
   isDisabled = false,
   isLoading = false,
+  className,
 }: Props) => {
   return (
     <button
@@ -30,7 +32,7 @@ const ButtonWithIcon = ({
         "cursor-pointer": !isDisabled,
       })}
     >
-      {!isLoading && <Icon aria-label={iconLabel} />}
+      {!isLoading && <Icon aria-label={iconLabel} className={className} />}
       {isLoading && <Spinner />}
       <span className="mt-1 hidden text-xs sm:flex">{children}</span>
     </button>

--- a/src/components/ImageDetailModal/index.tsx
+++ b/src/components/ImageDetailModal/index.tsx
@@ -1,6 +1,6 @@
 import { useState, Fragment, Suspense } from "react";
 import { toast } from "react-toastify";
-import { Heart, Copy, FolderDown, SendHorizontal, Siren, Trash2, Hash } from "lucide-react";
+import { Heart, Copy, FolderDown, SendHorizontal, Siren, Hash } from "lucide-react";
 import { useOverlay } from "@toss/use-overlay";
 import axios, { AxiosError } from "axios";
 import ReportConfirmModal from "@/components/ReportConfirmModal";
@@ -12,7 +12,6 @@ import TagSlider from "@/components/common/TagSlider";
 import Modal from "@/components/common/modals/Modal";
 import useGetZzalDetails from "@/hooks/api/zzal/useGetZzalDetails";
 import usePostReportZzal from "@/hooks/api/zzal/usePostReportZzal";
-import useDeleteMyZzal from "@/hooks/api/zzal/useDeleteMyZzal";
 
 interface Props {
   isOpen: boolean;
@@ -28,14 +27,10 @@ interface CustomErrorResponse {
 const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
   const [isTagNavigatorOpen, setIsTagNavigatorOpen] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
   const { zzalDetails } = useGetZzalDetails(imageId);
   const { reportZzal } = usePostReportZzal();
-  const { deleteMyZzal } = useDeleteMyZzal();
   const reportConfirmOverlay = useOverlay();
-  const { isLiked, imageUrl, tagNames, imageTitle, uploadUserId } = zzalDetails;
-  const isUploader = uploadUserId === 19;
-  //TODO: [2024.03.01] 추후 실제 사용자 아이디와 비교하기
+  const { isLiked, imageUrl, tagNames, imageTitle } = zzalDetails;
 
   const errorMessage = {
     REPORT_ALREADY_EXIST_ERROR: "이미 신고가 완료되었습니다.",
@@ -74,23 +69,6 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
       />
     ));
   };
-
-  const handleClickDeleteButton = debounce(() => {
-    setIsDeleting(true);
-
-    deleteMyZzal(imageId, {
-      onSuccess: () => {
-        toast.success("사진이 삭제되었습니다.");
-        gtag("event", "user_action", { event_category: "짤_삭제" });
-      },
-      onError: () => {
-        toast.error("사진 삭제에 실패했습니다.");
-      },
-      onSettled: () => {
-        setIsDeleting(false);
-      },
-    }); // TODO: [2024-03-15] 사진 삭제 로직 짤카드 호버 삭제버튼에 추가 후 옮기기
-  }, 500);
 
   const handleClickDownloadButton = debounce(async () => {
     setIsDownloading(true);
@@ -159,12 +137,11 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
               onClick={handleClickReportButton}
             />
             <ButtonWithIcon
-              Icon={Trash2}
-              iconLabel="삭제하기"
-              children="삭제하기"
-              isDisabled={!isUploader || isDeleting}
-              isLoading={isDeleting}
-              onClick={handleClickDeleteButton}
+              Icon={Heart}
+              iconLabel="좋아요"
+              children="좋아요"
+              onClick={handleClickLikeButton}
+              className={cn({ "fill-primary": isLiked })}
             />
           </div>
         </div>
@@ -183,17 +160,9 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
       <div className=" max-h-500pxr overflow-auto">
         <img src={imageUrl} alt={imageTitle} className="w-full" />
       </div>
-      <div className="fixed bottom-0 right-0 flex flex-col space-y-4 p-25pxr hover:text-gray-300">
+      <div className="fixed bottom-0 right-0 flex flex-col space-y-4 p-25pxr text-gray-300 hover:text-gray-200">
         <button onClick={handleClickCopyButton}>
-          <Copy color="white" size={30} aria-label="복사하기" />
-        </button>
-        <button onClick={handleClickLikeButton}>
-          <Heart
-            color="white"
-            size={30}
-            aria-label="좋아요"
-            className={cn({ "fill-primary": isLiked })}
-          />
+          <Copy size={33} aria-label="복사하기" />
         </button>
       </div>
     </Fragment>

--- a/src/components/common/DeleteConfirmModal.tsx
+++ b/src/components/common/DeleteConfirmModal.tsx
@@ -15,7 +15,8 @@ const DeleteConfirmModal = ({ isOpen, onClose, onDelete }: Props) => {
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size="sm">
+    <Modal isOpen={isOpen} onClose={onClose} className="p-40pxr">
+      <Modal.Header hasCloseButton />
       <Modal.Body>
         <div className="flex flex-col items-center">
           <AlertTriangle color="#ED0000" strokeWidth="1.2" size="84" aria-label="경고삼각형" />

--- a/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { toast } from "react-toastify";
 import { createLazyFileRoute } from "@tanstack/react-router";
 import { XCircle } from "lucide-react";
 import { useSetAtom } from "jotai";
@@ -27,7 +28,15 @@ const MyUploadedZzals = () => {
   }, [topTags, setRecommendedTags]);
 
   const handleClickDeleteButton = (imageId: number) => () => {
-    deleteMyZzal(imageId);
+    deleteMyZzal(imageId, {
+      onSuccess: () => {
+        toast.success("사진이 삭제되었습니다.");
+        gtag("event", "user_action", { event_category: "짤_삭제" });
+      },
+      onError: () => {
+        toast.error("사진 삭제에 실패했습니다.");
+      },
+    });
   };
 
   return (

--- a/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
@@ -3,6 +3,7 @@ import { toast } from "react-toastify";
 import { createLazyFileRoute } from "@tanstack/react-router";
 import { XCircle } from "lucide-react";
 import { useSetAtom } from "jotai";
+import { useOverlay } from "@toss/use-overlay";
 import useGetTopTagsFromUploaded from "@/hooks/api/tag/useGetTopTagsFromUploaded";
 import useGetMyUploadedZzals from "@/hooks/api/zzal/useGetMyUploadedZzals";
 import useIntersectionObserver from "@/hooks/common/useIntersectionObserver";
@@ -10,6 +11,7 @@ import MasonryLayout from "@/components/common/MasonryLayout";
 import ZzalCard from "@/components/common/ZzalCard";
 import { $recommendedTags } from "@/store/tag";
 import useDeleteMyZzal from "@/hooks/api/zzal/useDeleteMyZzal";
+import DeleteConfirmModal from "@/components/common/DeleteConfirmModal";
 
 const MyUploadedZzals = () => {
   const { topTags } = useGetTopTagsFromUploaded();
@@ -17,6 +19,7 @@ const MyUploadedZzals = () => {
   const { deleteMyZzal } = useDeleteMyZzal();
   const setRecommendedTags = useSetAtom($recommendedTags);
   const fetchMoreRef = useRef(null);
+  const deleteConfirmOverlay = useOverlay();
 
   useIntersectionObserver({
     target: fetchMoreRef,
@@ -27,7 +30,7 @@ const MyUploadedZzals = () => {
     setRecommendedTags(topTags);
   }, [topTags, setRecommendedTags]);
 
-  const handleClickDeleteButton = (imageId: number) => () => {
+  const handleClickDeleteConfirm = (imageId: number) => () => {
     deleteMyZzal(imageId, {
       onSuccess: () => {
         toast.success("사진이 삭제되었습니다.");
@@ -37,6 +40,17 @@ const MyUploadedZzals = () => {
         toast.error("사진 삭제에 실패했습니다.");
       },
     });
+    gtag("event", "user_action", { event_category: "짤_삭제" });
+  };
+
+  const handleClickDeleteButton = (imageId: number) => () => {
+    deleteConfirmOverlay.open(({ isOpen, close }) => (
+      <DeleteConfirmModal
+        isOpen={isOpen}
+        onClose={close}
+        onDelete={handleClickDeleteConfirm(imageId)}
+      />
+    ));
   };
 
   return (

--- a/src/routes/admin/reports/$imageId/index.tsx
+++ b/src/routes/admin/reports/$imageId/index.tsx
@@ -22,7 +22,7 @@ const AdminImageDetail = () => {
 
   const handleClickDeleteConfirm = (imageId: string) => () => {
     deleteReportedZzal(imageId);
-    gtag("event", "user_action", { event_category: "짤_영구_삭제" });
+    gtag("event", "admin_action", { event_category: "짤_영구_삭제" });
   };
 
   const handleClickDeleteButton = () => {


### PR DESCRIPTION
## 📝 작업 내용

> 짤 상세 모달에서 삭제버튼을 제거했습니다.
짤 삭제 시 확인 모달, 토스트 기능 추가했습니다.
<img src="https://github.com/zzalmyu/zzalmyu-frontend/assets/107539614/5c090b82-285c-4c8c-849b-b123f3141430" alt="image" width="400" >

close #136 
