### PR TITLE
[#167] Fix: 액세스 토큰 null 오류 및 로그아웃 시 새로고침 수정

### DIFF
--- a/src/apis/core.ts
+++ b/src/apis/core.ts
@@ -23,7 +23,7 @@ axiosInstance.interceptors.request.use(async (config) => {
   const accessToken = getLocalStorage(ACCESS_TOKEN);
   const refreshToken = getLocalStorage(REFRESH_TOKEN);
 
-  config.headers.Authorization = `Bearer ${accessToken}`;
+  config.headers.Authorization = accessToken && `Bearer ${accessToken}`;
 
   if (refreshToken && isExpiredToken(refreshToken)) {
     toast.error("재로그인이 필요합니다", { autoClose: 2000 });

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -9,6 +9,7 @@ const useLogout = () => {
     onSuccess: () => {
       removeLocalStorage(ACCESS_TOKEN);
       removeLocalStorage(REFRESH_TOKEN);
+      location.reload();
     },
     onError: (error) => {
       console.error(error);


### PR DESCRIPTION
## 📝 작업 내용
- 액세스 토큰이 로컬 스토리지에 존재하지 않을 때 헤더에 null이 들어가게 되는 버그 수정
- 로그아웃 시 새로고침을 해 줌으로써 비회원 사용자에게 맞는 추천 및 이미지 제공

아주 간단한 수정입니다 ㅎ

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

# 📍 기타 (선택)


close #167 
