### PR TITLE
[#146] Feat: 검색 결과가 없는 경우 보여줄 컴포넌트 적용

### DIFF
--- a/src/components/common/NoSearchResults.tsx
+++ b/src/components/common/NoSearchResults.tsx
@@ -1,21 +1,40 @@
-import { SearchX } from "lucide-react";
+import { Fragment } from "react";
+import { useAtom } from "jotai";
+import { Search, SearchX } from "lucide-react";
+import { $selectedTags } from "@/store/tag";
 
-interface Props {
-  onClick: (isTagReset: boolean) => void;
-}
+const NoSearchResults = () => {
+  const [selectedTags, setSelectedTags] = useAtom($selectedTags);
 
-const NoSearchResults = ({ onClick }: Props) => {
+  const handleClickBackButton = () => {
+    setSelectedTags([]);
+  };
+
   return (
-    <div className="flex h-400pxr w-[35%] min-w-96 flex-col items-center rounded-xl bg-card">
-      <SearchX aria-label="검색 실패" size={60} className="mt-80pxr" />
-      <p className="mt-35pxr text-4xl">검색 결과가 없어요!</p>
-      <p className="mt-20pxr text-text-secondary">필터를 삭제하고 다시 시도해보세요.</p>
-      <button
-        className="mt-40pxr h-40pxr w-180pxr rounded-full bg-primary text-white"
-        onClick={() => onClick(true)}
-      >
-        되돌아가기
-      </button>
+    <div className="flex h-full w-full flex-col items-center justify-center">
+      {selectedTags.length === 0 && (
+        <Fragment>
+          <Search aria-label="검색" size={60} />
+          <div className="mt-35pxr text-center text-4xl">
+            <div>보유하신 짤이 없습니다!</div>
+            <div>짤들을 업로드 하거나 좋아요를 눌러보세요</div>
+          </div>
+        </Fragment>
+      )}
+
+      {selectedTags.length !== 0 && (
+        <Fragment>
+          <SearchX aria-label="검색 실패" size={60} />
+          <p className="mt-35pxr text-4xl">검색 결과가 없어요!</p>
+          <p className="mt-20pxr text-text-secondary">필터를 삭제하고 다시 시도해보세요.</p>
+          <button
+            className="mt-40pxr h-40pxr w-180pxr rounded-full bg-primary text-white"
+            onClick={handleClickBackButton}
+          >
+            되돌아가기
+          </button>
+        </Fragment>
+      )}
     </div>
   );
 };

--- a/src/routes/_layout-with-chat/my-liked-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-liked-zzals/route.lazy.tsx
@@ -7,6 +7,7 @@ import useIntersectionObserver from "@/hooks/common/useIntersectionObserver";
 import ZzalCard from "@/components/common/ZzalCard";
 import MasonryLayout from "@/components/common/MasonryLayout";
 import { $recommendedTags } from "@/store/tag";
+import NoSearchResults from "@/components/common/NoSearchResults";
 
 const MyLikedZzals = () => {
   const { zzals, handleFetchNextPage } = useGetMyLikedZzals();
@@ -24,7 +25,8 @@ const MyLikedZzals = () => {
   }, [topTags, setRecommendedTags]);
 
   return (
-    <div className="flex w-full flex-col items-center">
+    <div className="flex h-full w-full flex-col items-center">
+      {zzals.length === 0 && <NoSearchResults />}
       <MasonryLayout className="mt-15pxr w-full">
         {zzals.map(({ imageId, path, title, imageLikeYn }, index) => (
           <ZzalCard

--- a/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
@@ -9,6 +9,7 @@ import MasonryLayout from "@/components/common/MasonryLayout";
 import ZzalCard from "@/components/common/ZzalCard";
 import { $recommendedTags } from "@/store/tag";
 import useDeleteMyZzal from "@/hooks/api/zzal/useDeleteMyZzal";
+import NoSearchResults from "@/components/common/NoSearchResults";
 
 const MyUploadedZzals = () => {
   const { topTags } = useGetTopTagsFromUploaded();
@@ -31,7 +32,8 @@ const MyUploadedZzals = () => {
   };
 
   return (
-    <div className="flex w-full flex-col items-center">
+    <div className="flex h-full w-full flex-col items-center">
+      {zzals.length === 0 && <NoSearchResults />}
       <MasonryLayout className="mt-15pxr">
         {zzals.map(({ imageId, path, title, imageLikeYn }, index) => (
           <div className="relative" key={imageId}>


### PR DESCRIPTION
## 📝 작업 내용

기존에 구현되어 있던 `NoSearchResults` 컴포넌트 수정.
애초에 데이터가 없는 경우와 필터링한 결과가 없는 경우의 UI를 분리.

## 💬 리뷰 요구사항(선택)

애초에 데이터가 없는 경우 UI가 애매한데 의견 있으시면 적극적으로 주시면 감사하겠습니다 : )

close #146
