### PR TITLE
[#131] Feat: image detail modal에 좋아요 기능 연결

### DIFF
--- a/src/components/ImageDetailModal/index.tsx
+++ b/src/components/ImageDetailModal/index.tsx
@@ -3,6 +3,7 @@ import { toast } from "react-toastify";
 import { Heart, Copy, FolderDown, SendHorizontal, Siren, Hash } from "lucide-react";
 import { useOverlay } from "@toss/use-overlay";
 import axios, { AxiosError } from "axios";
+import { useAtom } from "jotai";
 import ReportConfirmModal from "@/components/ReportConfirmModal";
 import { cn } from "@/utils/tailwind";
 import { copyZzal, downloadZzal } from "@/utils/zzalUtils";
@@ -14,6 +15,7 @@ import useGetZzalDetails from "@/hooks/api/zzal/useGetZzalDetails";
 import usePostReportZzal from "@/hooks/api/zzal/usePostReportZzal";
 import { useRemoveImageDetailLike } from "@/hooks/api/zzal/useRemoveImageDetailLike";
 import { useAddImageDetailLike } from "@/hooks/api/zzal/useAddImageDetailLike";
+import { $userInformation } from "@/store/user";
 
 interface Props {
   isOpen: boolean;
@@ -35,6 +37,8 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
   const { isLiked, imageUrl, tagNames, imageTitle } = zzalDetails;
   const { addImageLike } = useAddImageDetailLike(imageId);
   const { removeImageLike } = useRemoveImageDetailLike(imageId);
+  const [userInformation] = useAtom($userInformation);
+  const { role } = userInformation;
 
   const errorMessage = {
     REPORT_ALREADY_EXIST_ERROR: "이미 신고가 완료되었습니다.",
@@ -64,6 +68,10 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
   };
 
   const handleClickReportButton = () => {
+    if (role !== "USER") {
+      toast.info("로그인이 필요한 서비스입니다.");
+      return;
+    }
     gtag("event", "modal_open", { event_category: "신고_확인_모달_띄우기" });
     reportConfirmOverlay.open(({ isOpen, close }) => (
       <ReportConfirmModal
@@ -90,6 +98,10 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
   }, 500);
 
   const handleClickLikeButton = () => {
+    if (role !== "USER") {
+      toast.info("로그인이 필요한 서비스입니다.");
+      return;
+    }
     if (!isLiked) {
       addImageLike(imageId, {
         onSuccess: () => {
@@ -111,7 +123,12 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
     });
   };
 
-  const handleClickSendButton = () => {};
+  const handleClickSendButton = () => {
+    if (role !== "USER") {
+      toast.info("로그인이 필요한 서비스입니다.");
+      return;
+    }
+  };
   //TODO: [2024.03.05] 해당 handler함수 로직 추가하기
 
   const toggleTagNavigator = () => {

--- a/src/components/ImageDetailModal/index.tsx
+++ b/src/components/ImageDetailModal/index.tsx
@@ -12,6 +12,8 @@ import TagSlider from "@/components/common/TagSlider";
 import Modal from "@/components/common/modals/Modal";
 import useGetZzalDetails from "@/hooks/api/zzal/useGetZzalDetails";
 import usePostReportZzal from "@/hooks/api/zzal/usePostReportZzal";
+import { useRemoveImageDetailLike } from "@/hooks/api/zzal/useRemoveImageDetailLike";
+import { useAddImageDetailLike } from "@/hooks/api/zzal/useAddImageDetailLike";
 
 interface Props {
   isOpen: boolean;
@@ -31,6 +33,8 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
   const { reportZzal } = usePostReportZzal();
   const reportConfirmOverlay = useOverlay();
   const { isLiked, imageUrl, tagNames, imageTitle } = zzalDetails;
+  const { addImageLike } = useAddImageDetailLike(imageId);
+  const { removeImageLike } = useRemoveImageDetailLike(imageId);
 
   const errorMessage = {
     REPORT_ALREADY_EXIST_ERROR: "이미 신고가 완료되었습니다.",
@@ -85,10 +89,29 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
     copyZzal(imageUrl);
   }, 500);
 
-  const handleClickLikeButton = () => {};
+  const handleClickLikeButton = () => {
+    if (!isLiked) {
+      addImageLike(imageId, {
+        onSuccess: () => {
+          gtag("event", "user_action", { event_category: "짤_좋아요_등록" });
+        },
+        onError: () =>
+          toast.error("좋아요 요청이 실패하였습니다 다시 시도해주세요.", { autoClose: 1500 }),
+      });
+
+      return;
+    }
+
+    removeImageLike(imageId, {
+      onSuccess: () => {
+        gtag("event", "user_action", { event_category: "짤_좋아요_삭제" });
+      },
+      onError: () =>
+        toast.error("좋아요 취소에 실패하였습니다 다시 시도해주세요.", { autoClose: 1500 }),
+    });
+  };
 
   const handleClickSendButton = () => {};
-
   //TODO: [2024.03.05] 해당 handler함수 로직 추가하기
 
   const toggleTagNavigator = () => {

--- a/src/components/ImageDetailModal/index.tsx
+++ b/src/components/ImageDetailModal/index.tsx
@@ -40,6 +40,14 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
   const [userInformation] = useAtom($userInformation);
   const { role } = userInformation;
 
+  const handleLoginRequiredAction = (onAction: () => void) => () => {
+    if (role !== "USER") {
+      toast.info("로그인이 필요한 서비스입니다.");
+      return;
+    }
+    onAction();
+  };
+
   const errorMessage = {
     REPORT_ALREADY_EXIST_ERROR: "이미 신고가 완료되었습니다.",
     DEFAULT: "신고가 올바르게 되지 않았습니다.",
@@ -67,11 +75,7 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
     });
   };
 
-  const handleClickReportButton = () => {
-    if (role !== "USER") {
-      toast.info("로그인이 필요한 서비스입니다.");
-      return;
-    }
+  const handleClickReportButton = handleLoginRequiredAction(() => {
     gtag("event", "modal_open", { event_category: "신고_확인_모달_띄우기" });
     reportConfirmOverlay.open(({ isOpen, close }) => (
       <ReportConfirmModal
@@ -80,7 +84,7 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
         onReport={handleClickReportCompeleteButton(imageId)}
       />
     ));
-  };
+  });
 
   const handleClickDownloadButton = debounce(async () => {
     setIsDownloading(true);
@@ -97,11 +101,7 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
     copyZzal(imageUrl);
   }, 500);
 
-  const handleClickLikeButton = () => {
-    if (role !== "USER") {
-      toast.info("로그인이 필요한 서비스입니다.");
-      return;
-    }
+  const handleClickLikeButton = handleLoginRequiredAction(() => {
     if (!isLiked) {
       addImageLike(imageId, {
         onSuccess: () => {
@@ -121,19 +121,12 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
       onError: () =>
         toast.error("좋아요 취소에 실패하였습니다 다시 시도해주세요.", { autoClose: 1500 }),
     });
-  };
+  });
 
-  const handleClickSendButton = () => {
-    if (role !== "USER") {
-      toast.info("로그인이 필요한 서비스입니다.");
-      return;
-    }
-  };
+  const handleClickSendButton = handleLoginRequiredAction(() => {});
   //TODO: [2024.03.05] 해당 handler함수 로직 추가하기
 
-  const toggleTagNavigator = () => {
-    setIsTagNavigatorOpen(!isTagNavigatorOpen);
-  };
+  const toggleTagNavigator = () => setIsTagNavigatorOpen(!isTagNavigatorOpen);
 
   return (
     <Fragment>

--- a/src/hooks/api/zzal/useAddImageDetailLike.ts
+++ b/src/hooks/api/zzal/useAddImageDetailLike.ts
@@ -1,0 +1,32 @@
+import { useQueryClient, useMutation } from "@tanstack/react-query";
+import { postImageLike } from "@/apis/zzal";
+import { GetZzalDetailsResponse } from "@/types/zzal.dto";
+
+export const useAddImageDetailLike = (imageId: number) => {
+  const queryClient = useQueryClient();
+
+  const { mutate, ...rest } = useMutation({
+    mutationFn: (imageId: number) => postImageLike(imageId),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ["zzalDetails", imageId] });
+
+      const oldData = queryClient.getQueryData<GetZzalDetailsResponse>(["zzalDetails", imageId]);
+
+      if (!oldData) return;
+
+      const updatedData = oldData;
+
+      updatedData.imageLikeYn = true;
+
+      queryClient.setQueryData(["zzalDetails", imageId], updatedData);
+
+      return { oldData };
+    },
+    onError: (error, _zzalId, context) => {
+      console.error(error);
+      queryClient.setQueryData(["zzalDetails", imageId], context?.oldData);
+    },
+  });
+
+  return { addImageLike: mutate, ...rest };
+};

--- a/src/hooks/api/zzal/useAddImageDetailLike.ts
+++ b/src/hooks/api/zzal/useAddImageDetailLike.ts
@@ -14,7 +14,7 @@ export const useAddImageDetailLike = (imageId: number) => {
 
       if (!oldData) return;
 
-      const updatedData = oldData;
+      const updatedData = JSON.parse(JSON.stringify(oldData));
 
       updatedData.imageLikeYn = true;
 
@@ -22,8 +22,7 @@ export const useAddImageDetailLike = (imageId: number) => {
 
       return { oldData };
     },
-    onError: (error, _zzalId, context) => {
-      console.error(error);
+    onError: (_error, _zzalId, context) => {
       queryClient.setQueryData(["zzalDetails", imageId], context?.oldData);
     },
   });

--- a/src/hooks/api/zzal/useRemoveImageDetailLike.ts
+++ b/src/hooks/api/zzal/useRemoveImageDetailLike.ts
@@ -1,0 +1,32 @@
+import { useQueryClient, useMutation } from "@tanstack/react-query";
+import { deleteImageLike } from "@/apis/zzal";
+import { GetZzalDetailsResponse } from "@/types/zzal.dto";
+
+export const useRemoveImageDetailLike = (imageId: number) => {
+  const queryClient = useQueryClient();
+
+  const { mutate, ...rest } = useMutation({
+    mutationFn: (imageId: number) => deleteImageLike(imageId),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ["zzalDetails", imageId] });
+
+      const oldData = queryClient.getQueryData<GetZzalDetailsResponse>(["zzalDetails", imageId]);
+
+      if (!oldData) return;
+
+      const updatedData = oldData;
+
+      updatedData.imageLikeYn = false;
+
+      queryClient.setQueryData(["zzalDetails", imageId], updatedData);
+
+      return { oldData };
+    },
+    onError: (error, _zzalId, context) => {
+      console.error(error);
+      queryClient.setQueryData(["zzalDetails", imageId], context?.oldData);
+    },
+  });
+
+  return { removeImageLike: mutate, ...rest };
+};

--- a/src/hooks/api/zzal/useRemoveImageDetailLike.ts
+++ b/src/hooks/api/zzal/useRemoveImageDetailLike.ts
@@ -14,7 +14,7 @@ export const useRemoveImageDetailLike = (imageId: number) => {
 
       if (!oldData) return;
 
-      const updatedData = oldData;
+      const updatedData = JSON.parse(JSON.stringify(oldData));
 
       updatedData.imageLikeYn = false;
 
@@ -22,8 +22,7 @@ export const useRemoveImageDetailLike = (imageId: number) => {
 
       return { oldData };
     },
-    onError: (error, _zzalId, context) => {
-      console.error(error);
+    onError: (_error, _zzalId, context) => {
       queryClient.setQueryData(["zzalDetails", imageId], context?.oldData);
     },
   });


### PR DESCRIPTION
## 📝 작업 내용

> 짤 디테일 모달에 좋아요 기능 연결
-  짤 디테일 모달에 사용될 좋아요 api 훅 구현 (낙관적 업데이트) 
- 짤 디테일 모달에 좋아요 기능 연결
- 기존의 기존 좋아요 훅인 useAddImageLike훅과 useRemoveImageLike훅을 사용할 시에 짤 상세 모달에서의 낙관적 업데이트를 하기 어려워
짤 상세모달 좋아요 기능에 사용될 훅을 새롭게 구현했습니다.

## 💬 리뷰 요구사항(선택)

- 짤 상세모달에서 좋아요를 누르거나 삭제 할 때 짤 상세모달을 부른 **기존 페이지에도 낙관적 업데이트가 바로 적용**되야할까요? 

기존 페이지, 짤 상세모달 모두 낙관적 업데이트가 동시에 적용될 필요성이 있다면 각각의 훅에 있는 낙관적 업데이트 코드를 **하나의 훅에 그냥 합쳐도 좋을 것 같다**는 생각이 드네요.



close #131
