### PR TITLE
[#178] Fix: 언마운트 후 재마운트 시 infiniteQuery 버그 fix

### DIFF
--- a/src/hooks/api/zzal/useGetHomeZzals.ts
+++ b/src/hooks/api/zzal/useGetHomeZzals.ts
@@ -16,6 +16,7 @@ const useGetHomeZzlas = () => {
         return lastPageParam + 1;
       },
       initialPageParam: 0,
+      refetchOnMount: false,
     });
 
   const handleFetchNextPage = () => {
@@ -26,10 +27,10 @@ const useGetHomeZzlas = () => {
 
   return {
     zzals: data?.pages.flatMap((page) => page),
-    handleFetchNextPage,
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    handleFetchNextPage,
     ...rest,
   };
 };

--- a/src/hooks/api/zzal/useGetMyLikedZzals.ts
+++ b/src/hooks/api/zzal/useGetMyLikedZzals.ts
@@ -16,6 +16,7 @@ const useGetMyLikedZzals = () => {
         return lastPageParam + 1;
       },
       initialPageParam: 0,
+      refetchOnMount: false,
     });
 
   const handleFetchNextPage = () => {

--- a/src/hooks/api/zzal/useGetMyUploadedZzals.ts
+++ b/src/hooks/api/zzal/useGetMyUploadedZzals.ts
@@ -16,6 +16,7 @@ const useGetMyUploadedZzals = () => {
         return lastPageParam + 1;
       },
       initialPageParam: 0,
+      refetchOnMount: false,
     });
 
   const handleFetchNextPage = () => {


### PR DESCRIPTION
# [#178] Fix: 언마운트 후 재마운트 시 infiniteQuery 버그 fix

## 📝 작업 내용

> useInfiniteQuery를 활용하는 hook에 refetchOnMount: false를 설정하여 bug를 해결했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

# 📍 기타 (선택)

> 다른 분들이 참고해야할 사항이 있다면 작성해주세요

close #178 
