### PR TITLE
[#184] Fix: TagSlider 화살표 버튼 렌더 버그 fix

### DIFF
--- a/src/components/common/SearchTag/TagSearchForm.tsx
+++ b/src/components/common/SearchTag/TagSearchForm.tsx
@@ -142,7 +142,9 @@ const TagSearchForm = ({ className }: Props) => {
             초기화
           </button>
         )}
-        <div className="w-full">{!showAutoComplete && <TagSlider tags={selectedTags} />}</div>
+        <div className="w-full">
+          <TagSlider tags={selectedTags} />
+        </div>
       </div>
     </div>
   );

--- a/src/components/common/TagSlider.tsx
+++ b/src/components/common/TagSlider.tsx
@@ -12,9 +12,10 @@ interface Props {
   tagClassName?: string;
   onClick?: () => void;
   isClickable?: boolean;
+  tagGap?: number;
 }
 
-const TagSlider = ({ tags, tagClassName, onClick, isClickable = true }: Props) => {
+const TagSlider = ({ tags, tagClassName, onClick, isClickable = true, tagGap = 5 }: Props) => {
   const [mainImageIndex, setMainImageIndex] = useState(0);
   const navigationPrevRef = useRef<HTMLButtonElement>(null);
   const navigationNextRef = useRef<HTMLButtonElement>(null);
@@ -37,7 +38,7 @@ const TagSlider = ({ tags, tagClassName, onClick, isClickable = true }: Props) =
     <div className={"relative flex bg-none"}>
       <Swiper
         slidesPerView={"auto"}
-        spaceBetween={10}
+        spaceBetween={tagGap}
         allowTouchMove={false}
         slideToClickedSlide={true}
         pagination={{

--- a/src/components/common/TagSlider.tsx
+++ b/src/components/common/TagSlider.tsx
@@ -15,8 +15,6 @@ interface Props {
 }
 
 const TagSlider = ({ tags, tagClassName, onClick, isClickable = true }: Props) => {
-  const [showPrevButton, setShowPrevButton] = useState(false);
-  const [showNextButton, setShowNextButton] = useState(true);
   const [mainImageIndex, setMainImageIndex] = useState(0);
   const navigationPrevRef = useRef<HTMLButtonElement>(null);
   const navigationNextRef = useRef<HTMLButtonElement>(null);
@@ -36,10 +34,10 @@ const TagSlider = ({ tags, tagClassName, onClick, isClickable = true }: Props) =
   };
 
   return (
-    <div className={"relative flex bg-none "}>
+    <div className={"relative flex bg-none"}>
       <Swiper
         slidesPerView={"auto"}
-        spaceBetween={15}
+        spaceBetween={10}
         allowTouchMove={false}
         slideToClickedSlide={true}
         pagination={{
@@ -49,40 +47,23 @@ const TagSlider = ({ tags, tagClassName, onClick, isClickable = true }: Props) =
         onBeforeInit={handleBeforeInit}
         className="h-auto w-full"
         onSlideChange={(event) => setMainImageIndex(event.activeIndex)}
-        onReachBeginning={() => {
-          setShowPrevButton(false);
-        }}
-        onReachEnd={() => {
-          setShowNextButton(false);
-        }}
-        onFromEdge={() => {
-          setShowPrevButton(true);
-          setShowNextButton(true);
-        }}
       >
         <button
-          className={cn(
-            "absolute top-0 z-10 h-full bg-gradient-to-r from-background from-70% pr-7pxr",
-            {
-              hidden: !showPrevButton,
-            },
-          )}
+          className="absolute top-0 z-10 h-full bg-gradient-to-r from-background from-70% pr-7pxr disabled:hidden"
           onMouseDown={(event) => event.preventDefault()}
           ref={navigationPrevRef}
           aria-label="이전으로 이동"
         >
           <ChevronLeft strokeWidth={1.5} />
         </button>
-
         {tags.map((tagName, index) => (
           <SwiperSlide
             key={`${index}-${tagName}`}
-            className={cn("w-fit cursor-pointer px-5pxr text-center text-text-primary", {
-              "pr-50pxr": index === tags.length - 1,
-              "pl-30pxr": index === 0 && showPrevButton,
+            className={cn("w-fit cursor-pointer px-2 text-center text-text-primary", {
+              "pr-20pxr": index === tags.length - 1,
             })}
           >
-            <button onClick={onClick}>
+            <button onClick={onClick} className={cn({ "cursor-default": !onClick })}>
               <TagBadge
                 content={tagName}
                 className={cn("px-2 py-1 text-xs", tagClassName)}
@@ -92,12 +73,7 @@ const TagSlider = ({ tags, tagClassName, onClick, isClickable = true }: Props) =
           </SwiperSlide>
         ))}
         <button
-          className={cn(
-            "absolute right-0 top-0 z-10 h-full bg-gradient-to-l from-background from-70% pl-7pxr",
-            {
-              hidden: !showNextButton,
-            },
-          )}
+          className="absolute right-0 top-0 z-10 h-full bg-gradient-to-l from-background from-70% pl-7pxr disabled:hidden"
           onMouseDown={(event) => event.preventDefault()}
           ref={navigationNextRef}
           aria-label="다음으로 이동"


### PR DESCRIPTION
## 📝 작업 내용

> TagSlider에 화살표 버튼이 제대로 동작하지 않는 버그를 수정했습니다.
-  벳지를 동적으로 추가할 때 TagSlider에 Next화살표 버튼이 바로 적용되지 않음
- 슬라이더 내부의 벳지들의 사이즈가 애매하게 슬라이더 사이즈와 맞아 떨어질 때 Next화살표 버튼이 사라지지 않음

해결: 
- arrow버튼의 show상태관리 코드를 다 제거했습니다. 
- Swiper 내부적으로 버튼이 disabled될때 hidden되도록 코드를 변경했습니다. 

이전에 있던 문제 모두 해결된 거 같습니다. 확인부탁드립니다:)

close #184 
