### PR TITLE
[#187] Fix: pathname 변경시 선택된 태그 초기화

### DIFF
--- a/src/routes/_layout-with-chat.tsx
+++ b/src/routes/_layout-with-chat.tsx
@@ -1,14 +1,22 @@
-import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
-import { useAtom } from "jotai";
+import { useEffect } from "react";
+import { Outlet, createFileRoute, redirect, useRouterState } from "@tanstack/react-router";
+import { useAtom, useSetAtom } from "jotai";
 import { MessageCircle } from "lucide-react";
 import axios from "axios";
 import { cn } from "@/utils/tailwind";
 import Chat from "@/components/common/Chat";
 import { $isChatOpen } from "@/store/chat";
 import TagSearchForm from "@/components/common/SearchTag/TagSearchForm";
+import { $selectedTags } from "@/store/tag";
 
 const LayoutWithChat = () => {
+  const { location } = useRouterState();
+  const setSelectedTags = useSetAtom($selectedTags);
   const [isChatOpen, setIsChatOpen] = useAtom($isChatOpen);
+
+  useEffect(() => {
+    setSelectedTags([]);
+  }, [location.pathname, setSelectedTags]);
 
   const handleClickChatToggleButton = () => {
     setIsChatOpen((prev) => !prev);


### PR DESCRIPTION
## 📝 작업 내용

페이지별로 페이지 진입시에 useEffect 내에서 선택된 태그를 초기화 시켜주려고 했습니다.
그러나, 페이지들의 route.lazy.tsx 안에 검색창이 있는 것이 아니라, layout-with-chat에 검색창이 있다보니 초기화를 시켜줘도 반영이 되지 않았습니다.
`TagSearchForm`이 unmount 될때 초기화 해줄까도 싶었지만 마찬가지로 `layout-with-chat`에 있다보니 unmount되는 순간도 없더라구요.
결국 `layout-with-chat` 내부에서 pathname이 변경될때마다 초기화 해주도록 수정해두었습니다.

좋은 방법인지에 대한 의문이 있네요ㅠ
이 부분에 대해 자유롭게 얘기 나눠보면 좋을 것 같습니다!

close #187
