### PR TITLE
[#186] Style: 자동완성 검색창 다크 모드 적용

### DIFF
--- a/src/components/ImageDetailModal/index.tsx
+++ b/src/components/ImageDetailModal/index.tsx
@@ -154,7 +154,7 @@ const ImageDetailModalContent = ({ imageId }: { imageId: number }) => {
             },
           )}
         >
-          <TagSlider tags={tagNames} tagClassName="bg-primary" isClickable={false} />
+          <TagSlider tags={tagNames} tagClassName="bg-primary text-white" isClickable={false} />
         </div>
       </div>
       <div className=" max-h-500pxr overflow-auto">

--- a/src/components/UploadZzal/UploadTagAutoComplete.tsx
+++ b/src/components/UploadZzal/UploadTagAutoComplete.tsx
@@ -31,11 +31,11 @@ const UploadTagAutoComplete = ({ autoCompletedTags, cursorIndex, setCursorIndex 
   };
 
   return (
-    <div className="absolute top-[-5px] box-border w-full rounded-b-25pxr border border-t-0 border-gray-300 bg-white px-4 pb-4 pt-[40px] shadow-xl outline-none sm:rounded-b-30pxr">
+    <div className="absolute top-[-5px] box-border w-full rounded-b-25pxr border border-t-0 border-gray-300 bg-background px-4 pb-4 pt-[40px] shadow-xl outline-none sm:rounded-b-30pxr">
       <hr className="absolute left-0 top-25pxr w-full sm:top-30pxr" />
       {selectedTags.length > 0 && (
         <div className="mb-10pxr border-b-2">
-          <div className="text-10pxr mb-20pxr font-semibold text-neutral">
+          <div className="text-10pxr mb-20pxr font-semibold text-text-primary">
             선택된 태그
             <span className="ml-5pxr">
               {selectedTags.length}/{MAX_SEARCH_TAG_UPLOAD}
@@ -71,7 +71,7 @@ const UploadTagAutoComplete = ({ autoCompletedTags, cursorIndex, setCursorIndex 
           </li>
         ))}
       </ul>
-      <div className="text-10pxr font-semibold text-neutral">추천 태그</div>
+      <div className="text-10pxr font-semibold text-text-primary">추천 태그</div>
       <ul>
         {recommendedTags.map(({ tagId, tagName }, index) => {
           const recommendedIndex = index + autoCompletedTags.length;
@@ -86,8 +86,8 @@ const UploadTagAutoComplete = ({ autoCompletedTags, cursorIndex, setCursorIndex 
               )}
               onMouseDown={handleMouseDownTagName(tagId, tagName)}
             >
-              <div className="flex items-center gap-2">
-                <Bookmark size={16} color="#807F7F" />
+              <div className="flex items-center gap-2 text-text-primary">
+                <Bookmark size={16} />
                 {tagName}
               </div>
             </li>

--- a/src/components/UploadZzal/UploadTagBadge.tsx
+++ b/src/components/UploadZzal/UploadTagBadge.tsx
@@ -25,7 +25,7 @@ const UploadTagBadge = ({ tagId, tagName, isClickable = false, className }: Prop
   return (
     <span
       className={cn(
-        "flex w-fit items-center rounded-3xl bg-black p-1 text-[14px] font-bold text-white",
+        "flex w-fit items-center rounded-3xl bg-badge p-1 text-[14px] font-bold text-text-tertiary",
         className,
       )}
     >

--- a/src/components/common/SearchTag/TagAutoComplete.tsx
+++ b/src/components/common/SearchTag/TagAutoComplete.tsx
@@ -31,11 +31,11 @@ const TagAutoComplete = ({ autoCompletedTags, cursorIndex, setCursorIndex }: Pro
   };
 
   return (
-    <div className="absolute top-[-5px] z-10 box-border w-full rounded-b-25pxr border border-t-0 border-gray-300 bg-white px-4 pb-4 pt-[40px] shadow-xl outline-none sm:rounded-b-30pxr">
+    <div className="absolute top-[-5px] z-10 box-border w-full rounded-b-25pxr border border-t-0 border-gray-300 bg-background px-4 pb-4 pt-[40px] shadow-xl outline-none sm:rounded-b-30pxr">
       <hr className="absolute left-0 top-25pxr w-full sm:top-30pxr" />
       {selectedTags.length > 0 && (
         <div className="mb-10pxr border-b-2">
-          <div className="text-10pxr mb-20pxr font-semibold text-neutral">
+          <div className="text-10pxr mb-20pxr font-semibold text-text-primary">
             선택된 태그
             <span className="ml-5pxr">
               {selectedTags.length}/{MAX_SEARCH_TAG}
@@ -69,7 +69,7 @@ const TagAutoComplete = ({ autoCompletedTags, cursorIndex, setCursorIndex }: Pro
           </li>
         ))}
       </ul>
-      <div className="text-10pxr font-semibold text-neutral">추천 태그</div>
+      <div className="text-10pxr font-semibold text-text-primary">추천 태그</div>
       <ul>
         {recommendedTags.map(({ tagId, tagName }, index) => {
           const recommendedIndex = index + autoCompletedTags.length;
@@ -84,8 +84,8 @@ const TagAutoComplete = ({ autoCompletedTags, cursorIndex, setCursorIndex }: Pro
               )}
               onMouseDown={handleMouseDownTagName(tagName)}
             >
-              <div className="flex items-center gap-2">
-                <Bookmark size={16} color="#807F7F" />
+              <div className="flex items-center gap-2 text-text-primary">
+                <Bookmark size={16} />
                 {tagName}
               </div>
             </li>

--- a/src/components/common/SearchTag/TagSearchForm.tsx
+++ b/src/components/common/SearchTag/TagSearchForm.tsx
@@ -115,9 +115,9 @@ const TagSearchForm = ({ className }: Props) => {
           />
           <button
             type="submit"
-            className="z-20 flex items-center gap-6pxr rounded-full bg-primary text-white sm:p-2"
+            className="z-20 flex items-center gap-6pxr rounded-full bg-gradient-to-r from-primary from-30% to-[#78C6FF] p-1 text-sm font-bold text-white sm:px-2.5 sm:py-2 sm:text-base"
           >
-            <Search aria-label="검색" size={20} />
+            <Search aria-label="검색" size={17} strokeWidth={3} />
             검색
           </button>
         </div>

--- a/src/components/common/TagBadge.tsx
+++ b/src/components/common/TagBadge.tsx
@@ -20,7 +20,7 @@ const TagBadge = ({ content, isClickable = false, className }: Props) => {
   return (
     <span
       className={cn(
-        "flex-column flex w-fit items-center rounded-3xl bg-black p-1 text-[14px] font-bold text-white",
+        "flex w-fit items-center rounded-3xl bg-badge p-1 text-[14px] font-bold text-text-tertiary",
         className,
       )}
     >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,6 +46,7 @@ export default {
         secondary: "var(--secondary)",
         "text-primary": "rgb(var(--text-primary) / <alpha-value>)",
         "text-secondary": "var(--text-secondary)",
+        "text-tertiary": "var(--text-tertiary)",
         surface1: "var(--surface1)",
         surface2: "var(--surface2)",
         background: "var(--background)",
@@ -55,6 +56,7 @@ export default {
         icon: "var(--icon)",
         delete: "#ED0000",
         tag: "#570DF8",
+        badge: "var(--badge)"
       },
     },
   },
@@ -67,6 +69,7 @@ export default {
           "--secondary": "#E2F4FF",
           "--text-primary": "0 0 0",
           "--text-secondary": "#535353",
+          "--text-tertiary":"#FFFFFF",
           "--surface1": "#78C6FF",
           "--surface2": "#FFB015",
           "--background": "#FFFFFF",
@@ -74,12 +77,14 @@ export default {
           "--tooltip": "#535353",
           "--toolbar": "#858383",
           "--icon": "#807F7F",
+          "--badge": "#000000"
         },
         dark: {
           ...require("daisyui/src/theming/themes")["dark"],
           "--secondary": "#2600BD",
           "--text-primary": "255 255 255",
           "--text-secondary": "#8EB4FF",
+          "--text-tertiary":"#000000",
           "--surface1": "#552AFF",
           "--surface2": "#B2B9FF",
           "--background": "#000D27",
@@ -87,6 +92,7 @@ export default {
           "--tooltip": "#11419E",
           "--toolbar": "#002873",
           "--icon": "#FFFFFF",
+          "--badge": "#FFFFFF"
         },
       },
     ],


### PR DESCRIPTION
## 📝 작업 내용

> 자동완성 검색창 다크 모드 적용
- 짤 페이지 자동완성 검색창 
- 업로드 페이지 자동완성 검색창
- 태그 벳지에 사용되는 배경색(badge) 텍스트색(text-tertiary)이 tailwind config에 추가 되었습니다. 

### 📷 스크린샷 (선택)
![chrome_pUAnuz95ix](https://github.com/zzalmyu/zzalmyu-frontend/assets/107539614/942cbb92-9bd2-47ff-a559-8960a53019ef)



close #186
