### PR TITLE
[#189] Fix: 짤 업로드시 query key invalidate

### DIFF
--- a/src/hooks/api/zzal/usePostUploadZzal.ts
+++ b/src/hooks/api/zzal/usePostUploadZzal.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { postUploadZzal } from "@/apis/zzal";
 
 interface Props {
@@ -8,8 +8,13 @@ interface Props {
 }
 
 const usePostUploadZzal = () => {
+  const queryClient = useQueryClient();
+
   const { mutate, ...rest } = useMutation({
     mutationFn: ({ file, tagIdList, title }: Props) => postUploadZzal({ file, tagIdList, title }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["uploadedZzals"] });
+    },
   });
 
   return { uploadZzal: mutate, ...rest };

--- a/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
@@ -55,7 +55,7 @@ const MyUploadedZzals = () => {
 
   return (
     <div className="flex w-full flex-col items-center">
-      <MasonryLayout className="mt-15pxr">
+      <MasonryLayout className="mt-15pxr w-full">
         {zzals.map(({ imageId, path, title, imageLikeYn }, index) => (
           <div className="relative" key={imageId}>
             <ZzalCard


### PR DESCRIPTION
## 📝 작업 내용

짤 업로드 훅에서 업로드 성공시 query key invalidate가 빠져있었습니다.
업로드한 짤 페이지 요청에 해당하는 쿼리키를 invalidate시켜주었습니다.

+ masonry layout에 w-full 추가했습니다.

close #189
