### PR TITLE
[#194] Style: 다크모드 적용 및 스타일 수정

### DIFF
--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const LoginModal = ({ isOpen, onClose }: Props) => {
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose} className="p-40pxr">
       <Modal.Header>로그인</Modal.Header>
       <Modal.Body>
         <div className="flex flex-col items-center gap-3">

--- a/src/components/common/ZzalCard.tsx
+++ b/src/components/common/ZzalCard.tsx
@@ -99,14 +99,13 @@ const LikeButton = ({ imageId, isLiked, imageIndex, queryKey }: LikeButtonProps)
 
   return (
     <button
-      className="mt-1 flex h-8 w-8 items-center justify-center rounded-full bg-white"
+      className="mt-1 flex h-9 w-9 items-center justify-center rounded-full bg-white"
       onClick={handleClickImageLike}
     >
       <Heart
         aria-label="좋아요"
         size={18}
-        strokeWidth={isLiked ? 0 : 2}
-        fill={isLiked ? "#ED0000" : "none"}
+        className={cn({ "fill-primary text-primary": isLiked, "text-black": !isLiked })}
       />
     </button>
   );
@@ -124,10 +123,10 @@ const SendButton = ({ src }: SendButtonProps) => {
 
   return (
     <button
-      className="mt-1 flex h-8 w-8 items-center justify-center rounded-full bg-primary"
+      className="mt-1 flex h-9 w-9 items-center justify-center rounded-full bg-primary"
       onClick={handleClickSendImageSrc}
     >
-      <SendHorizontal aria-label="채팅창 보내기" size={20} fill="white" />
+      <SendHorizontal aria-label="채팅창 보내기" size={18} color="white" />
     </button>
   );
 };
@@ -142,10 +141,10 @@ const CopyButton = ({ src }: CopyButtonProps) => {
 
   return (
     <button
-      className="mt-1 flex h-8 w-8 items-center justify-center rounded-full bg-primary"
+      className="mt-1 flex h-9 w-9 items-center justify-center rounded-full bg-primary"
       onClick={handleClickCopytoClipboard}
     >
-      <Copy aria-label="이미지 복사" size={20} stroke="white" />
+      <Copy aria-label="이미지 복사" size={18} color="white" />
     </button>
   );
 };

--- a/src/components/common/modals/Modal.tsx
+++ b/src/components/common/modals/Modal.tsx
@@ -40,7 +40,7 @@ const Modal = ({ children, isOpen, onClose, size = "md", className }: Props) => 
             className={cn(
               MODAL_HEIGHT_VARIANTS[size],
               MODAL_WIDTH_VARIANTS[size],
-              "fixed left-[50%] top-[50%] z-50 -translate-x-1/2 -translate-y-1/2 overflow-x-hidden rounded-32pxr bg-background text-text-primary ",
+              "fixed left-[50%] top-[50%] z-50 -translate-x-1/2 -translate-y-1/2 overflow-x-hidden rounded-32pxr bg-background text-text-primary",
               className,
             )}
             onClick={handleClickModal}

--- a/src/components/common/modals/ModalHeader.tsx
+++ b/src/components/common/modals/ModalHeader.tsx
@@ -10,7 +10,7 @@ const ModalHeader = ({ hasCloseButton = false, children }: Props) => {
   const onClose = useModalContext();
 
   return (
-    <div className="relative my-10 text-xl font-extrabold">
+    <div className="relative mb-10 text-xl font-extrabold">
       <div className="flex justify-center">{children}</div>
       {hasCloseButton && (
         <button

--- a/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { toast } from "react-toastify";
 import { createLazyFileRoute } from "@tanstack/react-router";
-import { XCircle } from "lucide-react";
+import { Trash2 } from "lucide-react";
 import { useSetAtom } from "jotai";
 import { useOverlay } from "@toss/use-overlay";
 import useGetTopTagsFromUploaded from "@/hooks/api/tag/useGetTopTagsFromUploaded";
@@ -57,7 +57,7 @@ const MyUploadedZzals = () => {
     <div className="flex w-full flex-col items-center">
       <MasonryLayout className="mt-15pxr">
         {zzals.map(({ imageId, path, title, imageLikeYn }, index) => (
-          <div className="relative" key={imageId}>
+          <div className="group relative" key={imageId}>
             <ZzalCard
               className="mb-10pxr"
               src={path}
@@ -67,12 +67,14 @@ const MyUploadedZzals = () => {
               isLiked={imageLikeYn}
               queryKey="uploadedZzals"
             />
-            <XCircle
-              onClick={handleClickDeleteButton(imageId)}
-              className="absolute right-2 top-2 z-0"
-              fill="white"
-              aria-label="짤 삭제"
-            />
+            <div className="button-container absolute bottom-5 left-2 z-10 flex w-fit gap-1.5 opacity-0 transition-opacity duration-500 ease-in-out group-hover:opacity-100">
+              <button
+                className="flex h-9 w-9 items-center justify-center rounded-full  bg-white"
+                onClick={handleClickDeleteButton(imageId)}
+              >
+                <Trash2 aria-label="짤 삭제" size={18} className="text-gray-700" />
+              </button>
+            </div>
           </div>
         ))}
       </MasonryLayout>


### PR DESCRIPTION
## 📝 작업 내용

- [x] 모달 레이아웃 깨짐 수정
- [x]  짤카드 버튼 스타일 수정
- [x] 업로드한 페이지 짤 카드 삭제 버튼 스타일 수정
짤 카드 버튼은 라이트 모트 다크 모드 동일하게 했습니다. 
더 좋은 아이디어있다면 알려주시면 감사하겠습니다:) 

추후에 삭제 버튼도 짤카드 내부로 이동하면 좋을 것 같습니다

### 📷 스크린샷 (선택)
![image](https://github.com/zzalmyu/zzalmyu-frontend/assets/107539614/2d787641-e9ca-4812-bf50-dbae5daa686f)


close #194 