### PR TITLE
[#200] Modify: 헤더의 admin버튼 드롭다운메뉴 버튼으로 변경

### DIFF
--- a/src/components/common/Header/DropdownMenu.tsx
+++ b/src/components/common/Header/DropdownMenu.tsx
@@ -2,6 +2,7 @@ import { useRef } from "react";
 import { Home, Heart, FolderUp, LogOut } from "lucide-react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useAtom } from "jotai";
+import { Siren } from "lucide-react";
 import { getLocalStorage } from "@/utils/localStorage";
 import { REFRESH_TOKEN } from "@/constants/auth";
 import useLogout from "@/hooks/api/auth/useLogout";
@@ -18,7 +19,7 @@ const DropdownMenu = () => {
   const navigate = useNavigate();
   const { logout } = useLogout();
   const [userInformation, setUserInformation] = useAtom($userInformation);
-  const { email } = userInformation;
+  const { role, email } = userInformation;
   const userName = email.split("@")[0];
 
   const handleClickButton =
@@ -46,7 +47,7 @@ const DropdownMenu = () => {
     }
   };
 
-  const menuItems = [
+  const userMenuItems = [
     {
       path: "/my-uploaded-zzals/",
       Icon: FolderUp,
@@ -74,33 +75,57 @@ const DropdownMenu = () => {
     },
   ];
 
+  const adminMenuItems = [
+    {
+      path: "/",
+      Icon: Home,
+      name: "홈",
+      event: { category: "page_view", eventName: "홈_페이지로_이동" },
+    },
+    {
+      path: "/admin/reports/",
+      Icon: Siren,
+      name: "신고된 짤",
+      event: { category: "page_view", eventName: "신고된_짤_페이지로_이동" },
+    },
+    {
+      path: "/",
+      Icon: LogOut,
+      name: "로그아웃",
+      onClick: handleClickLogout,
+      event: { category: "user_action", eventName: "로그아웃" },
+    },
+  ];
+
   return (
     <ul className="menu menu-horizontal z-20 hidden px-0 sm:block">
       <li>
         <details ref={detailsRef}>
           <summary className="h-9 font-bold text-text-primary hover:bg-gray-300 focus:bg-transparent">
-            {userName}
+            {role === "USER" ? userName : "Admin"}
           </summary>
-          <ul className="right-1 z-[1] w-44 rounded-box bg-background text-text-primary ">
-            {menuItems.map(({ path, Icon, name, onClick, event }, index) => (
-              <li key={`${index}-${name}`} className="group" onClick={onClick || toggleDetails}>
-                <Link
-                  to={path}
-                  className="[&.active]:text-white "
-                  activeProps={{ className: "bg-transparent" }}
-                  onClick={handleClickButton(event)}
-                >
-                  <div className="h-6 w-6 group-hover:text-blue-500">
-                    <Icon size={20} aria-label={name} />
-                  </div>
-                  <span className="text-right font-bold group-hover:text-blue-500">{name}</span>
-                </Link>
-              </li>
-            ))}
+          <ul className="right-1 z-[1] w-44 rounded-box bg-background text-text-primary">
+            {(role === "USER" ? userMenuItems : adminMenuItems).map(
+              ({ path, Icon, name, onClick, event }, index) => (
+                <li key={`${index}-${name}`} className="group" onClick={onClick || toggleDetails}>
+                  <Link
+                    to={path}
+                    className="[&.active]:text-white "
+                    activeProps={{ className: "bg-transparent" }}
+                    onClick={handleClickButton(event)}
+                  >
+                    <div className="h-6 w-6 group-hover:text-blue-500">
+                      <Icon size={20} aria-label={name} />
+                    </div>
+                    <span className="text-right font-bold group-hover:text-blue-500">{name}</span>
+                  </Link>
+                </li>
+              ),
+            )}
             {refreshToken && (
               <Link
                 to="/delete-account"
-                className="mt-2pxr block text-center text-[9px] text-gray-700 underline"
+                className="mt-3pxr block text-center text-[9px] text-text-primary text-opacity-70 underline"
                 onClick={toggleDetails}
               >
                 계정 탈퇴하기

--- a/src/components/common/Header/DropdownMenu.tsx
+++ b/src/components/common/Header/DropdownMenu.tsx
@@ -77,12 +77,6 @@ const DropdownMenu = () => {
 
   const adminMenuItems = [
     {
-      path: "/",
-      Icon: Home,
-      name: "홈",
-      event: { category: "page_view", eventName: "홈_페이지로_이동" },
-    },
-    {
       path: "/admin/reports/",
       Icon: Siren,
       name: "신고된 짤",
@@ -122,7 +116,7 @@ const DropdownMenu = () => {
                 </li>
               ),
             )}
-            {refreshToken && (
+            {refreshToken && role === "USER" && (
               <Link
                 to="/delete-account"
                 className="mt-3pxr block text-center text-[9px] text-text-primary text-opacity-70 underline"

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, Fragment } from "react";
+import { useEffect } from "react";
 import { Link } from "@tanstack/react-router";
 import { useOverlay } from "@toss/use-overlay";
 import { useAtom } from "jotai";
@@ -40,10 +40,6 @@ const Header = () => {
     gtag("event", "page_view", { event_category: "짤_업로드_페이지로_이동" });
   };
 
-  const handleClickAdminButton = () => {
-    gtag("event", "page_view", { event_category: "관리자_페이지로_이동" });
-  };
-
   return (
     <div className="navbar bg-background">
       <Link
@@ -57,35 +53,18 @@ const Header = () => {
       <div className="flex flex-1 items-center justify-end space-x-1 px-2 sm:space-x-3">
         <ThemeToggle />
         {role === "USER" && (
-          <Fragment>
-            <Link to="/upload-zzal" onClick={handleClickUploadButton}>
-              <button className="btn hidden h-9 min-h-9 border-primary bg-primary text-white hover:bg-gray-300 sm:block">
-                업로드
-              </button>
-            </Link>
-            <div className="hidden h-6 w-0.5 bg-text-primary sm:block"></div>
-            <DropdownMenu />
-          </Fragment>
-        )}
-        {role === "GUEST" && (
-          <Fragment>
-            <div className="hidden h-6 w-0.5 bg-text-primary sm:block"></div>
-            <button className="btn btn-ghost h-6 min-h-9" onClick={handleClickLogin}>
-              로그인
+          <Link to="/upload-zzal" onClick={handleClickUploadButton}>
+            <button className="btn hidden h-9 min-h-9 border-primary bg-primary text-white hover:bg-gray-300 sm:block">
+              업로드
             </button>
-          </Fragment>
+          </Link>
         )}
-        {role === "ADMIN" && (
-          <Fragment>
-            <div className="hidden h-6 w-0.5 bg-text-primary sm:block"></div>
-            <Link
-              to="/admin/reports"
-              className="btn btn-ghost h-6 min-h-9 text-text-primary"
-              onClick={handleClickAdminButton}
-            >
-              Admin
-            </Link>
-          </Fragment>
+        <div className="hidden h-6 w-0.5 bg-text-primary sm:block"></div>
+        {role !== "GUEST" && <DropdownMenu />}
+        {role === "GUEST" && (
+          <button className="btn btn-ghost h-6 min-h-9" onClick={handleClickLogin}>
+            로그인
+          </button>
         )}
       </div>
     </div>


### PR DESCRIPTION
## 📝 작업 내용

> 현재 관리자로 로그인시에 로그아웃 할 수 있는 버튼이 없습니다.
그래서 관리자 Admin버튼도 User버튼과 마찬가지로 드롭다운 메뉴로 변경했습니다.

## 💬 리뷰 요구사항(선택)
- 기존 드롭다운 컴포넌트에 관리자메뉴아이템을 추가해서 구현했는데 적절한 방법인지 고민이 되네요😅

### 📷 스크린샷 (선택)
![image](https://github.com/zzalmyu/zzalmyu-frontend/assets/107539614/5534e10a-25f8-4d2c-ab85-3022092f5acc)



close #200 
