### PR TITLE
[#202] Fix: 리프레시 토큰 만료 시, 로그아웃 됨과 동시에 루트로 이동되지 않는 버그 수정

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,3 +1,4 @@
+import { toast } from "react-toastify";
 import axios from "axios";
 import { getLocalStorage } from "@/utils/localStorage";
 import { GetUserInformationResponse } from "@/types/user.dto";
@@ -5,13 +6,24 @@ import { ReissueTokenResponse } from "@/types/auth.dto";
 import http from "./core";
 import { REFRESH_TOKEN } from "@/constants/auth";
 
-export const patchLogOut = () =>
-  http.patch<void>({
-    headers: {
-      "Authorization-refresh": `Bearer ${getLocalStorage(REFRESH_TOKEN)}`,
-    },
-    url: "/v1/user/logout",
-  });
+export const patchLogOut = async () => {
+  const refreshToken = getLocalStorage(REFRESH_TOKEN);
+
+  try {
+    await axios.patch<void>(
+      `${import.meta.env.VITE_BASE_URL}/v1/user/logout`,
+      {},
+      {
+        headers: {
+          "Authorization-refresh": `Bearer ${refreshToken}`,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  } catch (error) {
+    toast.error("로그아웃에 실패하였습니다 다시 시도해 주십시오.");
+  }
+};
 
 export const postReissueToken = async (): Promise<{
   accessTokenResponse: string;

--- a/src/apis/core.ts
+++ b/src/apis/core.ts
@@ -1,4 +1,3 @@
-import { toast } from "react-toastify";
 import axios, { AxiosInstance, AxiosRequestConfig, Method } from "axios";
 import * as Sentry from "@sentry/react";
 import { getLocalStorage, removeLocalStorage, setLocalStorage } from "@/utils/localStorage";
@@ -27,11 +26,10 @@ axiosInstance.interceptors.request.use(async (config) => {
   config.headers.Authorization = accessToken && `Bearer ${accessToken}`;
 
   if (refreshToken && isExpiredToken(refreshToken)) {
-    toast.error("재로그인이 필요합니다", { autoClose: 2000 });
+    await patchLogOut();
+
     removeLocalStorage(ACCESS_TOKEN);
     removeLocalStorage(REFRESH_TOKEN);
-
-    await patchLogOut();
 
     window.location.href = "/";
 


### PR DESCRIPTION
## 📝 작업 내용

> 리프레시 토큰 만료 시, 로그아웃 됨과 동시에 루트로 이동되지 않는 버그 수정

경로가 이동됨에 따라 토스트 메시지가 보이다가 사라져서 토스트 메세지를 제거했습니다.
로그아웃 api를 axios instance를 사용하면 core의 request에서 계속해서 무한루프가 걸려 axios만 사용하여 리팩토링하였습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

# 📍 기타 (선택)

close #202 
