### PR TITLE
[#215] Fix: 다크모드에서 업로드 페이지 배경색 변경 및 자동완성 태그 호버 할 때 텍스트 색상 변경

### DIFF
--- a/src/components/UploadZzal/UploadTagAutoComplete.tsx
+++ b/src/components/UploadZzal/UploadTagAutoComplete.tsx
@@ -38,7 +38,7 @@ const UploadTagAutoComplete = ({
   };
 
   return (
-    <div className="absolute top-[-5px] box-border w-full rounded-b-25pxr border border-t-0 border-gray-300 bg-white px-4 pb-4 pt-[40px] shadow-xl outline-none sm:rounded-b-30pxr">
+    <div className="absolute top-[-5px] box-border w-full rounded-b-25pxr border border-t-0 border-gray-300 bg-background px-4 pb-4 pt-[40px] shadow-xl outline-none sm:rounded-b-30pxr">
       <hr className="absolute left-0 top-25pxr w-full sm:top-30pxr" />
       {selectedUploadTags.length > 0 && (
         <div className="mb-10pxr border-b-2">
@@ -64,7 +64,7 @@ const UploadTagAutoComplete = ({
             key={tagId}
             className={cn(
               "py-2",
-              index === cursorIndex && "box-border rounded-md bg-gray-200 font-bold",
+              index === cursorIndex && "box-border rounded-md bg-gray-200 font-bold text-black",
             )}
           >
             <div className="flex items-center gap-2">
@@ -85,11 +85,12 @@ const UploadTagAutoComplete = ({
               key={tagId}
               className={cn(
                 "px-2 py-2",
-                recommendedIndex === cursorIndex && "box-border rounded-md bg-gray-200 font-bold",
+                recommendedIndex === cursorIndex &&
+                  "box-border rounded-md bg-gray-200 font-bold text-black",
               )}
               onMouseDown={handleMouseDownTagName(tagId, tagName)}
             >
-              <div className="flex items-center gap-2 text-text-primary">
+              <div className="flex items-center gap-2">
                 <Bookmark size={16} />
                 {tagName}
               </div>

--- a/src/components/common/SearchTag/TagAutoComplete.tsx
+++ b/src/components/common/SearchTag/TagAutoComplete.tsx
@@ -66,7 +66,7 @@ const TagAutoComplete = ({
             key={tagId}
             className={cn(
               "py-2",
-              index === cursorIndex && "box-border rounded-md bg-gray-200 font-bold",
+              index === cursorIndex && "box-border rounded-md bg-gray-200 font-bold text-black",
             )}
           >
             <div className="flex items-center gap-2">
@@ -91,11 +91,12 @@ const TagAutoComplete = ({
               key={tagId}
               className={cn(
                 "px-2 py-2",
-                recommendedIndex === cursorIndex && "box-border rounded-md bg-gray-200 font-bold",
+                recommendedIndex === cursorIndex &&
+                  "box-border rounded-md bg-gray-200 font-bold text-black",
               )}
               onMouseDown={handleMouseDownTagName(tagName)}
             >
-              <div className="flex items-center gap-2 text-text-primary">
+              <div className="flex items-center gap-2">
                 <Bookmark size={16} />
                 {tagName}
               </div>

--- a/src/routes/_authentication/upload-zzal/index.tsx
+++ b/src/routes/_authentication/upload-zzal/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, Fragment, useEffect, useState } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { toast } from "react-toastify";
 import { Link, createFileRoute } from "@tanstack/react-router";
@@ -97,7 +97,7 @@ const UploadZzal = () => {
   }, [popularTags, setRecommendedTags]);
 
   return (
-    <Fragment>
+    <div className="h-full overflow-y-auto">
       <Helmet>
         <title>짤 업로드 - 짤뮤니티</title>
         <meta name="description" content="새로운 짤을 짤뮤니티에 업로드해보세요!" />
@@ -161,7 +161,7 @@ const UploadZzal = () => {
           </div>
         </div>
       </div>
-    </Fragment>
+    </div>
   );
 };
 


### PR DESCRIPTION
## 📝 작업 내용

다크모드에서 업로드 페이지 배경색 변경 및 자동완성 태그 호버 할 때 텍스트 색상 변경

- 이미지 업로드 페이지에 fragment 를 div로 변경하여 전체 높이를 가지고, overflow-y-auto 추가
- 다크모드에서 tagAutoComplete, uploadTagAutoComplete 호버 할 때 텍스트 색상 변경
- 
### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

# 📍 기타 (선택)

close #215 
