### PR TITLE
[#219] Fix: 업로드한 짤페이지 짤카드 레이아웃 깨짐 및 페이지 무한스크롤 에러 해결

### DIFF
--- a/src/components/common/ZzalCard.tsx
+++ b/src/components/common/ZzalCard.tsx
@@ -210,7 +210,7 @@ const DeleteButton = ({ imageId }: DeleteButtonProps) => {
 
   return (
     <button
-      className="mt-1 flex h-9 w-9 items-center justify-center rounded-full bg-primary"
+      className="mt-1 flex h-9 w-9 items-center justify-center rounded-full bg-black  bg-opacity-50 hover:bg-opacity-80"
       onClick={handleClickDeleteButton(imageId)}
     >
       <Trash2 aria-label="짤 삭제" size={18} className="text-white" />

--- a/src/routes/_layout-with-chat/my-liked-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-liked-zzals/route.lazy.tsx
@@ -26,7 +26,7 @@ const MyLikedZzals = () => {
   }, [topTags, setRecommendedTags]);
 
   return (
-    <div className="flex h-full w-full flex-col items-center">
+    <div className="flex w-full flex-col items-center">
       {zzals.length === 0 && <NoSearchResults />}
       <MasonryLayout className="mt-15pxr w-full">
         {zzals.map(({ imageId, path, title, imageLikeYn }, index) => (

--- a/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
@@ -1,27 +1,20 @@
 import { useEffect, useRef } from "react";
-import { toast } from "react-toastify";
 import { createLazyFileRoute } from "@tanstack/react-router";
-import { Trash2 } from "lucide-react";
 import { useAtom, useSetAtom } from "jotai";
-import { useOverlay } from "@toss/use-overlay";
 import useGetTopTagsFromUploaded from "@/hooks/api/tag/useGetTopTagsFromUploaded";
 import useGetMyUploadedZzals from "@/hooks/api/zzal/useGetMyUploadedZzals";
 import useIntersectionObserver from "@/hooks/common/useIntersectionObserver";
 import MasonryLayout from "@/components/common/MasonryLayout";
 import ZzalCard from "@/components/common/ZzalCard";
 import { $recommendedTags, $selectedTags } from "@/store/tag";
-import useDeleteMyZzal from "@/hooks/api/zzal/useDeleteMyZzal";
 import NoSearchResults from "@/components/common/NoSearchResults";
-import DeleteConfirmModal from "@/components/common/DeleteConfirmModal";
 
 const MyUploadedZzals = () => {
   const { topTags } = useGetTopTagsFromUploaded();
   const { zzals, handleFetchNextPage } = useGetMyUploadedZzals();
   const [selectedTags] = useAtom($selectedTags);
-  const { deleteMyZzal } = useDeleteMyZzal();
   const setRecommendedTags = useSetAtom($recommendedTags);
   const fetchMoreRef = useRef(null);
-  const deleteConfirmOverlay = useOverlay();
 
   useIntersectionObserver({
     target: fetchMoreRef,
@@ -32,53 +25,22 @@ const MyUploadedZzals = () => {
     setRecommendedTags(topTags);
   }, [topTags, setRecommendedTags]);
 
-  const handleClickDeleteConfirm = (imageId: number) => () => {
-    deleteMyZzal(imageId, {
-      onSuccess: () => {
-        toast.success("사진이 삭제되었습니다.");
-        gtag("event", "user_action", { event_category: "짤_삭제" });
-      },
-      onError: () => {
-        toast.error("사진 삭제에 실패했습니다.");
-      },
-    });
-    gtag("event", "user_action", { event_category: "짤_삭제" });
-  };
-
-  const handleClickDeleteButton = (imageId: number) => () => {
-    deleteConfirmOverlay.open(({ isOpen, close }) => (
-      <DeleteConfirmModal
-        isOpen={isOpen}
-        onClose={close}
-        onDelete={handleClickDeleteConfirm(imageId)}
-      />
-    ));
-  };
-
   return (
     <div className="flex h-full w-full flex-col items-center">
       {zzals.length === 0 && <NoSearchResults />}
       <MasonryLayout className="mt-15pxr w-full">
         {zzals.map(({ imageId, path, title, imageLikeYn }, index) => (
-          <div className="group relative" key={imageId}>
-            <ZzalCard
-              className="mb-10pxr"
-              src={path}
-              alt={title}
-              imageId={imageId}
-              imageIndex={index}
-              isLiked={imageLikeYn}
-              queryKey={["uploadedZzals", selectedTags]}
-            />
-            <div className="button-container absolute bottom-5 left-2 z-10 flex w-fit gap-1.5 opacity-0 transition-opacity duration-500 ease-in-out group-hover:opacity-100">
-              <button
-                className="flex h-9 w-9 items-center justify-center rounded-full  bg-white"
-                onClick={handleClickDeleteButton(imageId)}
-              >
-                <Trash2 aria-label="짤 삭제" size={18} className="text-gray-700" />
-              </button>
-            </div>
-          </div>
+          <ZzalCard
+            className="mb-10pxr"
+            key={`${imageId}-${index}`}
+            src={path}
+            alt={title}
+            imageId={imageId}
+            imageIndex={index}
+            isLiked={imageLikeYn}
+            queryKey={["uploadedZzals", selectedTags]}
+            hasDeleteButton={true}
+          />
         ))}
       </MasonryLayout>
       <div ref={fetchMoreRef} />

--- a/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
+++ b/src/routes/_layout-with-chat/my-uploaded-zzals/route.lazy.tsx
@@ -26,7 +26,7 @@ const MyUploadedZzals = () => {
   }, [topTags, setRecommendedTags]);
 
   return (
-    <div className="flex h-full w-full flex-col items-center">
+    <div className="flex w-full flex-col items-center">
       {zzals.length === 0 && <NoSearchResults />}
       <MasonryLayout className="mt-15pxr w-full">
         {zzals.map(({ imageId, path, title, imageLikeYn }, index) => (


### PR DESCRIPTION
## 📝 작업 내용

1.  업로드한 짤페이지 짤카드 레이아웃 깨짐 에러 해결
업로드한 페이지에서 삭제 버튼을 추가하기 위해 짤카드를 div로 감싸주었는데 채팅창이 열릴때 짤카드가 작아지지 않고 크기를 유지해 레이아웃이 꺠지는 이슈가 있었습니다. 

**해결**: 짤카드 내부에 삭제 버튼을 두어 짤카드를 감싸고 있던 div를 제거했습니다. 

2. 업로드한 짤, 좋아요 짤 페이지 무한 스크롤 에러 해결
메인 짤 페이지와 달리 좋아요 짤과 업로드한 짤에 가장 밖 div에 h-full이 추가되어 있었는데 이로 인해 <div ref={fetchMoreRef} />요소가 스크린 안으로 노출이 안되어 다음 데이터 로드가 안된게 원인이었습니다.

**해결**: 최상단 div에 있는 h-full 속성을 제거 했습니다. 

리뷰요청

- 짤 카드 내부에서 사용자 정보를 검사해서 삭제를 하도록 하는 등의 검증 로직을 추후에 추가해야할 것 같습니다. 
 
- 업로드한 페이지 짤카드 에러에서 div로감싸면 왜 짤카드가 사이즈가 안변하고 레이아웃이 깨지는지 혹시 이유 알고 계신 분 있으실까요..?

close #219
