### PR TITLE
[#220 ] Fix: useChat의 useInfiniteQuery hasNextPage 판별 로직 추가

### DIFF
--- a/src/hooks/api/chat/useGetChat.ts
+++ b/src/hooks/api/chat/useGetChat.ts
@@ -7,7 +7,7 @@ const useGetChat = () => {
       queryKey: ["chat"],
       queryFn: ({ pageParam = 0 }) => getChat(pageParam),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
-        if (!lastPage) return;
+        if (lastPage.length === 0) return;
 
         return lastPageParam + 1;
       },


### PR DESCRIPTION
# [#220 ] Fix: useChat의 useInfiniteQuery hasNextPage 판별 로직 추가

## 📝 작업 내용

> 채팅 useGetChat에서 사용되는 useInfiniteQuery에서 getNextPageParam이 lastPage가 null일 때 return하도록 되어 있는 것을 lastPage.length === 0일 때 return하도록 수정했습니다. 
- getChat api는 데이터가 없을 경우 빈 문자열을 반환합니다 

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

# 📍 기타 (선택)

- 다른 infiniteQuery에서도 적용해야 한다면 알려주시면 적용하도록 하겠습니다

close #220
