### PR TITLE
[#217] Fix: UploadSearchForm 이슈 수정

### DIFF
--- a/src/components/UploadZzal/UploadTagAutoComplete.tsx
+++ b/src/components/UploadZzal/UploadTagAutoComplete.tsx
@@ -38,11 +38,11 @@ const UploadTagAutoComplete = ({
   };
 
   return (
-    <div className="absolute top-[-5px] box-border w-full rounded-b-25pxr border border-t-0 border-gray-300 bg-background px-4 pb-4 pt-[40px] shadow-xl outline-none sm:rounded-b-30pxr">
+    <div className="absolute z-10 box-border w-full rounded-b-25pxr border border-t-0 border-gray-300 bg-background px-4 pb-4 pt-40pxr shadow-md outline-none sm:rounded-b-30pxr">
       <hr className="absolute left-0 top-25pxr w-full sm:top-30pxr" />
       {selectedUploadTags.length > 0 && (
         <div className="mb-10pxr border-b-2">
-          <div className="text-10pxr mb-20pxr font-semibold text-text-primary">
+          <div className="mb-10pxr text-sm font-semibold text-text-primary">
             선택된 태그
             <span className="ml-5pxr">
               {selectedUploadTags.length}/{MAX_SEARCH_TAG_UPLOAD}
@@ -74,7 +74,11 @@ const UploadTagAutoComplete = ({
           </li>
         ))}
       </ul>
-      <div className="text-10pxr font-semibold text-text-primary">추천 태그</div>
+
+      {recommendedTags.length && (
+        <div className="text-sm font-semibold text-neutral">추천 태그</div>
+      )}
+
       <ul>
         {recommendedTags.map(({ tagId, tagName }, index) => {
           const recommendedIndex = index + autoCompletedTags.length;

--- a/src/components/UploadZzal/UploadTagAutoComplete.tsx
+++ b/src/components/UploadZzal/UploadTagAutoComplete.tsx
@@ -48,9 +48,11 @@ const UploadTagAutoComplete = ({
               {selectedUploadTags.length}/{MAX_SEARCH_TAG_UPLOAD}
             </span>
           </div>
-          <div className="mb-10pxr flex flex-wrap gap-6pxr">
-            <TagSlider tags={selectedUploadTags.map(({ tagName }) => tagName)} />
-          </div>
+          <ul className="flex-column mb-10pxr flex flex-wrap gap-6pxr">
+            <div className="w-full">
+              <TagSlider tags={selectedUploadTags.map(({ tagName }) => tagName)} />
+            </div>
+          </ul>
         </div>
       )}
       <ul

--- a/src/components/UploadZzal/UploadTagSearchForm.tsx
+++ b/src/components/UploadZzal/UploadTagSearchForm.tsx
@@ -148,7 +148,7 @@ const UploadTagSearchForm = ({ className }: Props) => {
         <label htmlFor="tagInput" className="a11y-hidden">
           태그 입력
         </label>
-        <div className="flex h-full w-full flex-wrap items-center gap-2 rounded-full border border-gray-300 py-6pxr shadow-xl sm:gap-4 sm:px-4">
+        <div className="flex h-full w-full flex-wrap items-center gap-2 rounded-full border border-gray-300 px-2 py-0 shadow-md sm:gap-4 sm:px-4">
           <input
             id="tagInput"
             name="tag"
@@ -159,18 +159,34 @@ const UploadTagSearchForm = ({ className }: Props) => {
             autoComplete="off"
             minLength={1}
             maxLength={10}
-            className="z-20 min-h-12 flex-1 rounded-xl border-none bg-transparent py-6pxr outline-none"
+            className="z-20 h-50pxr min-h-8 flex-1 rounded-xl border-none bg-transparent outline-none sm:h-60pxr"
           />
           <button
             type="submit"
-            className="z-20 flex items-center gap-6pxr rounded-full bg-primary text-white sm:p-2"
+            className={cn(
+              "relative z-20 flex h-30pxr items-center gap-6pxr overflow-hidden rounded-full bg-primary p-2 text-white transition-[width_height] sm:h-35pxr  sm:p-2",
+              showAutoComplete ? "w-65pxr sm:w-70pxr" : "w-30pxr sm:w-35pxr",
+            )}
           >
-            <Search aria-label="검색" size={20} />
-            검색
+            <Search aria-label="검색" size={20} className="z-10" />
+            <span
+              className={cn(
+                "absolute right-2 z-10 text-sm transition-opacity delay-100 duration-200 sm:text-base",
+                showAutoComplete ? "opacity-100" : "translate-y-50pxr opacity-0",
+              )}
+            >
+              검색
+            </span>
+            <div
+              className={cn(
+                showAutoComplete ? "opacity-100" : "opacity-0",
+                "absolute inset-0 h-full w-full bg-gradient-to-r from-primary to-[#78C6FF] duration-300",
+              )}
+            ></div>
           </button>
         </div>
       </form>
-      <div className="absolute flex w-full justify-center sm:top-35pxr">
+      <div className="absolute top-25pxr flex w-full justify-center sm:top-30pxr">
         {showAutoComplete && (
           <UploadTagAutoComplete
             autoCompletedTags={autoCompletedTags}
@@ -180,14 +196,14 @@ const UploadTagSearchForm = ({ className }: Props) => {
           />
         )}
       </div>
-      <div className="mt-3 flex items-center">
+      <div className="mt-1 flex items-center justify-around sm:mt-0">
         {selectedUploadTags.length > 0 && (
           <button
             onClick={handleClickResetTagButton}
-            className="mr-4 flex items-center whitespace-nowrap rounded-full bg-card p-2"
+            className="mr-4 hidden items-center whitespace-nowrap rounded-full bg-card p-1 px-2 text-sm sm:flex sm:text-base"
             type="button"
           >
-            <RotateCw size={12} aria-label="태그 초기화" />
+            <RotateCw size={12} aria-label="태그 초기화" className="mr-1" />
             초기화
           </button>
         )}

--- a/src/components/UploadZzal/UploadTagSearchForm.tsx
+++ b/src/components/UploadZzal/UploadTagSearchForm.tsx
@@ -26,6 +26,7 @@ const UploadTagSearchForm = ({ className }: Props) => {
   const [cursorIndex, setCursorIndex] = useState(-1);
   const [uploadTagId, setUploadTagId] = useState<number>(-1);
   const [uploadTagName, setUploadTagName] = useState<string>("");
+  const allTags = [...autoCompletedTags, ...recommendedTags];
 
   const handleSubmitForm = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -33,16 +34,21 @@ const UploadTagSearchForm = ({ className }: Props) => {
     const formData = new FormData(event.currentTarget);
     const userInputTag = formData.get("tag") as string;
 
-    if (autoCompletedTags.length === 0 || userInputTag !== autoCompletedTags[0]?.tagName) {
-      createTag(userInputTag, {
-        onSuccess: (response) => {
-          setUploadTagName(userInputTag);
-          setUploadTagId(response.tagId);
-        },
-      });
+    if (cursorIndex === -1) {
+      if (autoCompletedTags.length === 0 || userInputTag !== autoCompletedTags[0]?.tagName) {
+        createTag(userInputTag, {
+          onSuccess: (response) => {
+            setUploadTagName(userInputTag);
+            setUploadTagId(response.tagId);
+          },
+        });
+      } else {
+        setUploadTagName(userInputTag);
+        setUploadTagId(autoCompletedTags[0].tagId);
+      }
     } else {
-      setUploadTagName(userInputTag);
-      setUploadTagId(autoCompletedTags[0].tagId);
+      setUploadTagName(allTags[cursorIndex].tagName);
+      setUploadTagId(allTags[cursorIndex].tagId);
     }
 
     setCursorIndex(-1);

--- a/src/components/UploadZzal/UploadTagSearchForm.tsx
+++ b/src/components/UploadZzal/UploadTagSearchForm.tsx
@@ -23,7 +23,7 @@ const UploadTagSearchForm = ({ className }: Props) => {
   const [tagKeyword, setTagKeyword] = useState("");
   const { autoCompletedTags } = useGetTags(tagKeyword);
   const [showAutoComplete, setShowAutoComplete] = useState(false);
-  const [cursorIndex, setCursorIndex] = useState(-2);
+  const [cursorIndex, setCursorIndex] = useState(-1);
   const [uploadTagId, setUploadTagId] = useState<number>(-1);
   const [uploadTagName, setUploadTagName] = useState<string>("");
 
@@ -45,7 +45,7 @@ const UploadTagSearchForm = ({ className }: Props) => {
       setUploadTagId(autoCompletedTags[0].tagId);
     }
 
-    setCursorIndex(0);
+    setCursorIndex(-1);
     setTagKeyword("");
     setShowAutoComplete(false);
   };
@@ -95,8 +95,8 @@ const UploadTagSearchForm = ({ className }: Props) => {
     setShowAutoComplete(true);
     setTagKeyword(event.target.value);
 
-    if (event.target.value.length > 0) setCursorIndex(-2);
-    else setCursorIndex(0);
+    if (event.target.value.length > 0) setCursorIndex(-1);
+    else setCursorIndex(-1);
   };
 
   useEffect(() => {

--- a/src/components/UploadZzal/UploadTagSearchForm.tsx
+++ b/src/components/UploadZzal/UploadTagSearchForm.tsx
@@ -202,7 +202,7 @@ const UploadTagSearchForm = ({ className }: Props) => {
           />
         )}
       </div>
-      <div className="mt-1 flex items-center justify-around sm:mt-0">
+      <div className="mt-1 flex items-center justify-start sm:mt-0">
         {selectedUploadTags.length > 0 && (
           <button
             onClick={handleClickResetTagButton}

--- a/src/components/UploadZzal/UploadTagSearchForm.tsx
+++ b/src/components/UploadZzal/UploadTagSearchForm.tsx
@@ -159,6 +159,12 @@ const UploadTagSearchForm = ({ className }: Props) => {
             autoComplete="off"
             minLength={1}
             maxLength={10}
+            onInput={(event: FormEvent<HTMLInputElement>) => {
+              const inputValue = event.currentTarget.value;
+              if (inputValue.length > 10) {
+                inputValue.slice(0, 10);
+              }
+            }}
             className="z-20 h-50pxr min-h-8 flex-1 rounded-xl border-none bg-transparent outline-none sm:h-60pxr"
           />
           <button


### PR DESCRIPTION
## 📝 작업 내용

- 키보드 keydown 시, enter 누르면 input text가 아닌 curser가 있는 곳의 태그가 select 되도록 수정
- 태그 등록 시, 최대 10글자로 제한
  - input 속성의 maxLenth를 이용했지만, 해결이 안된 이슈로 수정
  - input 의 onInput 속성 사용 (with. slice)
- TagSearchForm과 UI 동일하게 수정

## 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 📍 기타 (선택)

- ~TagSearchForm, TagAutoComplete와 UI 동일하게 수정하면서, TagSlider가 영역을 벗어났습니다.~ ->수정 완료
![image](https://github.com/zzalmyu/zzalmyu-frontend/assets/82134668/41321403-504f-4edd-85ba-349a8562e656)
![image](https://github.com/zzalmyu/zzalmyu-frontend/assets/82134668/44c16a79-09fc-4eb7-87b9-56f6f994321c)



close #217 
