### PR TITLE
[#226] Fix: 좋아요 또는 좋아요 취소 시 좋아요 페이지 캐싱 무효화

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,15 +29,15 @@ const queryClient = new QueryClient();
 
 const App = () => {
   return (
-    <HelmetProvider>
-      <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={queryClient}>
+      <HelmetProvider>
         <OverlayProvider>
           <AuthProvider>
             <InnerApp />
           </AuthProvider>
         </OverlayProvider>
-      </QueryClientProvider>
-    </HelmetProvider>
+      </HelmetProvider>
+    </QueryClientProvider>
   );
 };
 

--- a/src/hooks/api/zzal/useGetHomeZzals.ts
+++ b/src/hooks/api/zzal/useGetHomeZzals.ts
@@ -16,7 +16,7 @@ const useGetHomeZzals = () => {
         return lastPageParam + 1;
       },
       initialPageParam: 0,
-      refetchOnMount: false,
+      // refetchOnMount: false,
     });
 
   const handleFetchNextPage = () => {

--- a/src/hooks/api/zzal/useGetHomeZzals.ts
+++ b/src/hooks/api/zzal/useGetHomeZzals.ts
@@ -16,7 +16,6 @@ const useGetHomeZzals = () => {
         return lastPageParam + 1;
       },
       initialPageParam: 0,
-      // refetchOnMount: false,
     });
 
   const handleFetchNextPage = () => {

--- a/src/hooks/api/zzal/useGetMyLikedZzals.ts
+++ b/src/hooks/api/zzal/useGetMyLikedZzals.ts
@@ -16,7 +16,7 @@ const useGetMyLikedZzals = () => {
         return lastPageParam + 1;
       },
       initialPageParam: 0,
-      refetchOnMount: false,
+      // refetchOnMount: false,
     });
 
   const handleFetchNextPage = () => {

--- a/src/hooks/api/zzal/useGetMyLikedZzals.ts
+++ b/src/hooks/api/zzal/useGetMyLikedZzals.ts
@@ -16,7 +16,6 @@ const useGetMyLikedZzals = () => {
         return lastPageParam + 1;
       },
       initialPageParam: 0,
-      // refetchOnMount: false,
     });
 
   const handleFetchNextPage = () => {

--- a/src/hooks/api/zzal/useGetMyUploadedZzals.ts
+++ b/src/hooks/api/zzal/useGetMyUploadedZzals.ts
@@ -16,7 +16,6 @@ const useGetMyUploadedZzals = () => {
         return lastPageParam + 1;
       },
       initialPageParam: 0,
-      refetchOnMount: false,
     });
 
   const handleFetchNextPage = () => {

--- a/src/hooks/api/zzal/useRemoveImageLike.ts
+++ b/src/hooks/api/zzal/useRemoveImageLike.ts
@@ -9,19 +9,18 @@ export const useRemoveImageLike = (
   zzalKey: [ZzalType, string[]],
   imageId: number,
 ) => {
-  const zzalQueryClient = useQueryClient();
-  const zzalDetailQueryClient = useQueryClient();
+  const queryClient = useQueryClient();
 
   const { mutate, ...rest } = useMutation({
     mutationFn: (imageId: number) => deleteImageLike(imageId),
     onMutate: async () => {
       await Promise.all([
-        zzalQueryClient.cancelQueries({ queryKey: [...zzalKey] }),
-        zzalDetailQueryClient.cancelQueries({ queryKey: ["zzalDetails", imageId] }),
+        queryClient.cancelQueries({ queryKey: [...zzalKey] }),
+        queryClient.cancelQueries({ queryKey: ["zzalDetails", imageId] }),
       ]);
 
-      const zzalOldData = zzalQueryClient.getQueryData<GetZzalResponse>([...zzalKey]);
-      const zzalDetailOldData = zzalDetailQueryClient.getQueryData<GetZzalDetailsResponse>([
+      const zzalOldData = queryClient.getQueryData<GetZzalResponse>([...zzalKey]);
+      const zzalDetailOldData = queryClient.getQueryData<GetZzalDetailsResponse>([
         "zzalDetails",
         imageId,
       ]);
@@ -31,7 +30,7 @@ export const useRemoveImageLike = (
       if (zzalDetailOldData) {
         const zzalDetailUpdatedData = JSON.parse(JSON.stringify(zzalDetailOldData));
         zzalDetailUpdatedData.imageLikeYn = false;
-        zzalDetailQueryClient.setQueryData(["zzalDetails", imageId], zzalDetailUpdatedData);
+        queryClient.setQueryData(["zzalDetails", imageId], zzalDetailUpdatedData);
       }
 
       const zzalUpdatedData = JSON.parse(
@@ -41,14 +40,17 @@ export const useRemoveImageLike = (
         }),
       );
       zzalUpdatedData.pages[imageIndex].imageLikeYn = false;
-      zzalQueryClient.setQueryData([...zzalKey], zzalUpdatedData);
+      queryClient.setQueryData([...zzalKey], zzalUpdatedData);
 
       return { zzalOldData, zzalDetailOldData };
     },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["likedZzals"] });
+    },
     onError: (_error, _zzalId, context) => {
-      zzalQueryClient.setQueryData([...zzalKey], context?.zzalOldData);
+      queryClient.setQueryData([...zzalKey], context?.zzalOldData);
       if (context?.zzalDetailOldData) {
-        zzalDetailQueryClient.setQueryData(["zzalDetails", imageId], context?.zzalDetailOldData);
+        queryClient.setQueryData(["zzalDetails", imageId], context?.zzalDetailOldData);
       }
     },
   });

--- a/src/routes/_layout-with-chat.tsx
+++ b/src/routes/_layout-with-chat.tsx
@@ -121,7 +121,6 @@ const LayoutWithChat = () => {
 export const Route = createFileRoute("/_layout-with-chat")({
   component: LayoutWithChat,
   beforeLoad: async ({ context, location }) => {
-    console.log(location.pathname);
     if (location.pathname === "/") return;
     await context.authorize.isAuthenticated();
   },


### PR DESCRIPTION
## 📝 작업 내용

> 좋아요 또는 좋아요 취소 시 좋아요 페이지 캐싱 무효화

- QueryClientProvider를 최상단에 위치
- 캐싱 무효화가 안됐던 원인 중 하나인 refetchOnMount를 default(true)로 변경

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

# 📍 기타 (선택)

close #226 
