### PR TITLE
[#231] Fix: 서버 리프레시 토큰 관련 에러 핸들링 및 로그아웃 api에 누락된 header 추가

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -4,18 +4,19 @@ import { getLocalStorage } from "@/utils/localStorage";
 import { GetUserInformationResponse } from "@/types/user.dto";
 import { ReissueTokenResponse } from "@/types/auth.dto";
 import http from "./core";
-import { REFRESH_TOKEN } from "@/constants/auth";
+import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/constants/auth";
 
 export const patchLogOut = async () => {
   const refreshToken = getLocalStorage(REFRESH_TOKEN);
-
+  const accessToken = getLocalStorage(ACCESS_TOKEN);
   try {
     await axios.patch<void>(
       `${import.meta.env.VITE_BASE_URL}/v1/user/logout`,
       {},
       {
         headers: {
-          "Authorization-refresh": `Bearer ${refreshToken}`,
+          authorization: `Bearer ${accessToken}`,
+          "authorization-refresh": `Bearer ${refreshToken}`,
           "Content-Type": "application/json",
         },
       },

--- a/src/apis/core.ts
+++ b/src/apis/core.ts
@@ -57,8 +57,19 @@ axiosInstance.interceptors.response.use(
 
     return response.data;
   },
-  (error) => {
+  async (error) => {
     Sentry.captureException(error);
+
+    if (!axios.isAxiosError(error)) return;
+    if (
+      error.response?.status === 401 &&
+      error.response?.data.message === "refresh token이 유효하지 않습니다."
+    ) {
+      removeLocalStorage(ACCESS_TOKEN);
+      removeLocalStorage(REFRESH_TOKEN);
+
+      window.location.href = "/";
+    }
 
     return Promise.reject(error);
   },

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -9,7 +9,6 @@ const useLogout = () => {
     onSuccess: () => {
       removeLocalStorage(ACCESS_TOKEN);
       removeLocalStorage(REFRESH_TOKEN);
-      location.reload();
     },
   });
 


### PR DESCRIPTION
## 📝 작업 내용

- 서버 리프레시 토큰 관련 에러 핸들링 -> 로컬 스토리지 토큰 삭제 후 홈으로 이동
- 로그아웃 api에 누락된 accessToken header 추가
- 별 다른 기능을 하지 않는 reload 함수 제거

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

# 📍 기타 (선택)

close #231 
