### PR TITLE
[#233] Fix: TagSearchForm 배포 환경에서 깨짐 현상 fix

### DIFF
--- a/src/components/common/SearchTag/TagSearchForm.tsx
+++ b/src/components/common/SearchTag/TagSearchForm.tsx
@@ -120,7 +120,7 @@ const TagSearchForm = ({ className }: Props) => {
         <label htmlFor="tagInput" className="a11y-hidden">
           태그 입력
         </label>
-        <div className="flex h-full w-full flex-wrap items-center gap-2 rounded-full border border-gray-300 px-2 py-0 shadow-md shadow-adaptive-shadow sm:gap-4 sm:px-4">
+        <div className="flex h-full w-full items-center gap-2 rounded-full border border-gray-300 px-2 py-0 shadow-md shadow-adaptive-shadow sm:gap-4 sm:px-4">
           <input
             id="tagInput"
             name="tag"


### PR DESCRIPTION
# [#233] Fix: TagSearchForm 배포 환경에서 깨짐 현상 fix

## 📝 작업 내용

> 배포 환경에서 layout이 깨지는 현상이 발생하여 flex-wrap을 제거했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 📍 기타 (선택)

> 다른 분들이 참고해야할 사항이 있다면 작성해주세요

close #233
