### PR TITLE
[#239] Fix: 채팅 내역 조회 순서 이상 버그 fix

### DIFF
--- a/src/apis/chat.ts
+++ b/src/apis/chat.ts
@@ -1,8 +1,10 @@
 import { GetChatResponse, PostChatNicknameResponse } from "@/types/chat.dto";
 import http from "./core";
 
-export const getChat = (page: number) =>
-  http.get<GetChatResponse>({ url: `/v1/chat?page=${page}` });
+export const getChat = async (page: number) => {
+  const data = await http.get<GetChatResponse>({ url: `/v1/chat?page=${page}` });
+  return [...data].reverse();
+};
 
 export const postChatNickname = (email: string) =>
   http.post<PostChatNicknameResponse>({

--- a/src/hooks/api/chat/useGetChat.ts
+++ b/src/hooks/api/chat/useGetChat.ts
@@ -2,15 +2,19 @@ import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { getChat } from "@/apis/chat";
 
 const useGetChat = () => {
-  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, ...rest } =
+  const { data, hasNextPage, isFetchingNextPage, isFetching, fetchNextPage, ...rest } =
     useSuspenseInfiniteQuery({
       queryKey: ["chat"],
-      queryFn: ({ pageParam = 0 }) => getChat(pageParam),
+      queryFn: async ({ pageParam = 0 }) => await getChat(pageParam),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (lastPage.length === 0) return;
 
         return lastPageParam + 1;
       },
+      select: (data) => ({
+        pages: [...data.pages].reverse(),
+        pageParams: [...data.pageParams],
+      }),
       initialPageParam: 0,
       refetchOnWindowFocus: false,
       refetchOnMount: false,
@@ -22,8 +26,9 @@ const useGetChat = () => {
     }
   };
 
+  console.log(data, isFetchingNextPage, isFetching);
   return {
-    messageHistory: data?.pages.flatMap((page) => page.reverse()).reverse(),
+    messageHistory: data?.pages.flatMap((page) => page),
     handleFetchNextPage,
     hasNextPage,
     isFetchingNextPage,

--- a/src/hooks/api/chat/useGetChat.ts
+++ b/src/hooks/api/chat/useGetChat.ts
@@ -2,7 +2,7 @@ import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { getChat } from "@/apis/chat";
 
 const useGetChat = () => {
-  const { data, hasNextPage, isFetchingNextPage, isFetching, fetchNextPage, ...rest } =
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, ...rest } =
     useSuspenseInfiniteQuery({
       queryKey: ["chat"],
       queryFn: async ({ pageParam = 0 }) => await getChat(pageParam),
@@ -26,7 +26,6 @@ const useGetChat = () => {
     }
   };
 
-  console.log(data, isFetchingNextPage, isFetching);
   return {
     messageHistory: data?.pages.flatMap((page) => page),
     handleFetchNextPage,

--- a/src/hooks/chat/useChat.ts
+++ b/src/hooks/chat/useChat.ts
@@ -42,7 +42,7 @@ const useChat = (targetRef: RefObject<HTMLDivElement>) => {
             }
             const updatedPages = oldData.pages.map((page, idx) => {
               if (idx === 0) {
-                return [parsedMessages, ...page];
+                return [...page, parsedMessages];
               }
               return page;
             });


### PR DESCRIPTION
# [#239] Fix: 채팅 내역 조회 순서 이상 버그 fix

## 📝 작업 내용

기존에는 server data를 받아온 뒤, chat message를 그릴 때 정렬했다면 수정 후 api 호출 response 자체를 정렬해서 받아오도록 수정했습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

# 📍 기타 (선택)

> 다른 분들이 참고해야할 사항이 있다면 작성해주세요

close #239
