### PR TITLE
[#240] Fix: TagSearchButton shrink 방지

### DIFF
--- a/src/components/common/SearchTag/TagSearchForm.tsx
+++ b/src/components/common/SearchTag/TagSearchForm.tsx
@@ -134,7 +134,7 @@ const TagSearchForm = ({ className }: Props) => {
           <button
             type="submit"
             className={cn(
-              "relative z-20 flex h-30pxr items-center gap-6pxr overflow-hidden rounded-full bg-primary p-2 text-white transition-[width_height] sm:h-35pxr  sm:p-2",
+              "relative z-20 flex h-30pxr shrink-0 items-center gap-6pxr overflow-hidden rounded-full bg-primary p-2 text-white transition-[width_height] sm:h-35pxr  sm:p-2",
               showAutoComplete ? "w-65pxr sm:w-70pxr" : "w-30pxr sm:w-35pxr",
             )}
           >


### PR DESCRIPTION
# [#240] Fix: TagSearchButton shrink 방지


## 📝 작업 내용

> 모바일 환경에서 flex-grow: 1로 지정되어 있는 input 때문에 searchButton이 shrink해버리는 현상이 있었습니다. 이를 searchButton에 flex-shrink: 0 property를 부여하여 해결하였습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


# 📍 기타 (선택)

close #240 
