### PR TITLE
[#249] Refactor: 쿼리들을 효율적으로 관리할 수 있도록 queryOptions 객체를 사용하여 co-location 하는 방식으로 리팩토링

### DIFF
--- a/src/hooks/api/auth/queryKeyFactories.ts
+++ b/src/hooks/api/auth/queryKeyFactories.ts
@@ -2,8 +2,8 @@ import { queryOptions } from "@tanstack/react-query";
 import { getUserInformation } from "@/apis/auth";
 
 export const authQueries = {
-  all: () => ["auth"] as const,
-  userInformationKey: () => [...authQueries.all(), "userInfomation"] as const,
+  all: ["auth"] as const,
+  userInformationKey: () => [...authQueries.all, "userInfomation"] as const,
   getUserInformation: (refreshToken: string) =>
     queryOptions({
       queryKey: [...authQueries.userInformationKey()] as const,

--- a/src/hooks/api/auth/queryKeyFactories.ts
+++ b/src/hooks/api/auth/queryKeyFactories.ts
@@ -1,0 +1,13 @@
+import { queryOptions } from "@tanstack/react-query";
+import { getUserInformation } from "@/apis/auth";
+
+export const authQueries = {
+  all: () => ["auth"] as const,
+  userInformationKey: () => [...authQueries.all(), "userInfomation"] as const,
+  getUserInformation: (refreshToken: string) =>
+    queryOptions({
+      queryKey: [...authQueries.userInformationKey()] as const,
+      queryFn: getUserInformation,
+      enabled: !!refreshToken,
+    }),
+};

--- a/src/hooks/api/chat/queryKeyFactories.ts
+++ b/src/hooks/api/chat/queryKeyFactories.ts
@@ -2,8 +2,8 @@ import { infiniteQueryOptions } from "@tanstack/react-query";
 import { getChat } from "@/apis/chat";
 
 export const chatQueries = {
-  all: () => ["chat"] as const,
-  chatListKey: () => [...chatQueries.all(), "chatList"] as const,
+  all: ["chat"] as const,
+  chatListKey: () => [...chatQueries.all, "chatList"] as const,
   getChatList: () =>
     infiniteQueryOptions({
       queryKey: [...chatQueries.chatListKey()] as const,

--- a/src/hooks/api/chat/queryKeyFactories.ts
+++ b/src/hooks/api/chat/queryKeyFactories.ts
@@ -1,0 +1,24 @@
+import { infiniteQueryOptions } from "@tanstack/react-query";
+import { getChat } from "@/apis/chat";
+
+export const chatQueries = {
+  all: () => ["chat"] as const,
+  chatListKey: () => [...chatQueries.all(), "chatList"] as const,
+  getChatList: () =>
+    infiniteQueryOptions({
+      queryKey: [...chatQueries.chatListKey()] as const,
+      queryFn: async ({ pageParam = 0 }) => await getChat(pageParam),
+      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+        if (lastPage.length === 0) return;
+
+        return lastPageParam + 1;
+      },
+      select: (data) => ({
+        pages: [...data.pages].reverse(),
+        pageParams: [...data.pageParams],
+      }),
+      initialPageParam: 0,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+    }),
+};

--- a/src/hooks/api/report/queryKeyFactories.ts
+++ b/src/hooks/api/report/queryKeyFactories.ts
@@ -2,8 +2,8 @@ import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { getReportDetails, getReports } from "@/apis/report";
 
 export const reportQueries = {
-  all: () => ["report"] as const,
-  reportListKey: () => [...reportQueries.all(), "reportList"] as const,
+  all: ["report"] as const,
+  reportListKey: () => [...reportQueries.all, "reportList"] as const,
   getReportList: () =>
     infiniteQueryOptions({
       queryKey: [...reportQueries.reportListKey()] as const,
@@ -15,7 +15,7 @@ export const reportQueries = {
       },
       initialPageParam: 0,
     }),
-  reportDetailKey: () => [...reportQueries.all(), "reportDetail"] as const,
+  reportDetailKey: () => [...reportQueries.all, "reportDetail"] as const,
   getReportDetail: (imageId: string) =>
     queryOptions({
       queryKey: [...reportQueries.reportDetailKey(), imageId],

--- a/src/hooks/api/report/queryKeyFactories.ts
+++ b/src/hooks/api/report/queryKeyFactories.ts
@@ -1,0 +1,24 @@
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
+import { getReportDetails, getReports } from "@/apis/report";
+
+export const reportQueries = {
+  all: () => ["report"] as const,
+  reportListKey: () => [...reportQueries.all(), "reportList"] as const,
+  getReportList: () =>
+    infiniteQueryOptions({
+      queryKey: [...reportQueries.reportListKey()] as const,
+      queryFn: ({ pageParam = 0 }) => getReports(pageParam),
+      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+        if (!lastPage) return;
+
+        return lastPageParam + 1;
+      },
+      initialPageParam: 0,
+    }),
+  reportDetailKey: () => [...reportQueries.all(), "reportDetail"] as const,
+  getReportDetail: (imageId: string) =>
+    queryOptions({
+      queryKey: [...reportQueries.reportDetailKey(), imageId],
+      queryFn: () => getReportDetails(imageId),
+    }),
+};

--- a/src/hooks/api/tag/queryKeyFactories.ts
+++ b/src/hooks/api/tag/queryKeyFactories.ts
@@ -8,8 +8,8 @@ import {
 } from "@/apis/tag";
 
 export const tagQueries = {
-  all: () => ["tags"] as const,
-  tagListKey: () => [...tagQueries.all(), "tagList"] as const,
+  all: ["tag"] as const,
+  tagListKey: () => [...tagQueries.all, "tagList"] as const,
   getTagList: (tag: string) => {
     const MAX_TAG_RESPONSE_COUNT = 10;
 
@@ -19,25 +19,25 @@ export const tagQueries = {
       select: (tags) => tags.filter((_tag, index) => index < MAX_TAG_RESPONSE_COUNT),
     });
   },
-  popularTagsKey: () => [...tagQueries.all(), "popularTags"] as const,
+  popularTagsKey: () => [...tagQueries.all, "popularTags"] as const,
   getPopularTags: () =>
     queryOptions({
       queryKey: [...tagQueries.popularTagsKey()] as const,
       queryFn: getPopularTags,
     }),
-  topTagsFromHomeKey: () => [...tagQueries.all(), "topTagsFromHome"] as const,
+  topTagsFromHomeKey: () => [...tagQueries.all, "topTagsFromHome"] as const,
   getTopTagsFromHome: () =>
     queryOptions({
       queryKey: [...tagQueries.topTagsFromHomeKey()] as const,
       queryFn: getTopTagsFromHome,
     }),
-  topTagsFromLikedKey: () => [...tagQueries.all(), "topTagsFromLiked"] as const,
+  topTagsFromLikedKey: () => [...tagQueries.all, "topTagsFromLiked"] as const,
   getTopTagsFromLiked: () =>
     queryOptions({
       queryKey: [...tagQueries.topTagsFromLikedKey()] as const,
       queryFn: getTopTagsFromLiked,
     }),
-  topTagsFromUploadedKey: () => [...tagQueries.all(), "topTagsFromUploaded"] as const,
+  topTagsFromUploadedKey: () => [...tagQueries.all, "topTagsFromUploaded"] as const,
   getTopTagsFromUploaded: () =>
     queryOptions({
       queryKey: [...tagQueries.topTagsFromUploadedKey()] as const,

--- a/src/hooks/api/tag/queryKeyFactories.ts
+++ b/src/hooks/api/tag/queryKeyFactories.ts
@@ -1,0 +1,46 @@
+import { queryOptions } from "@tanstack/react-query";
+import {
+  getPopularTags,
+  getSearchTag,
+  getTopTagsFromHome,
+  getTopTagsFromLiked,
+  getTopTagsFromUploaded,
+} from "@/apis/tag";
+
+export const tagQueries = {
+  all: () => ["tags"] as const,
+  tagListKey: () => [...tagQueries.all(), "tagList"] as const,
+  getTagList: (tag: string) => {
+    const MAX_TAG_RESPONSE_COUNT = 10;
+
+    return queryOptions({
+      queryKey: [...tagQueries.tagListKey(), tag] as const,
+      queryFn: () => getSearchTag(tag),
+      select: (tags) => tags.filter((_tag, index) => index < MAX_TAG_RESPONSE_COUNT),
+    });
+  },
+  popularTagsKey: () => [...tagQueries.all(), "popularTags"] as const,
+  getPopularTags: () =>
+    queryOptions({
+      queryKey: [...tagQueries.popularTagsKey()] as const,
+      queryFn: getPopularTags,
+    }),
+  topTagsFromHomeKey: () => [...tagQueries.all(), "topTagsFromHome"] as const,
+  getTopTagsFromHome: () =>
+    queryOptions({
+      queryKey: [...tagQueries.topTagsFromHomeKey()] as const,
+      queryFn: getTopTagsFromHome,
+    }),
+  topTagsFromLikedKey: () => [...tagQueries.all(), "topTagsFromLiked"] as const,
+  getTopTagsFromLiked: () =>
+    queryOptions({
+      queryKey: [...tagQueries.topTagsFromLikedKey()] as const,
+      queryFn: getTopTagsFromLiked,
+    }),
+  topTagsFromUploadedKey: () => [...tagQueries.all(), "topTagsFromUploaded"] as const,
+  getTopTagsFromUploaded: () =>
+    queryOptions({
+      queryKey: [...tagQueries.topTagsFromUploadedKey()] as const,
+      queryFn: getTopTagsFromUploaded,
+    }),
+};

--- a/src/hooks/api/zzal/queryKeyFactories.ts
+++ b/src/hooks/api/zzal/queryKeyFactories.ts
@@ -2,8 +2,8 @@ import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { getHomeZzals, getMyLikedZzals, getMyUploadedZzals, getZzalDetails } from "@/apis/zzal";
 
 export const zzalQueries = {
-  all: () => ["zzal"] as const,
-  zzalDetailKey: () => [...zzalQueries.all(), "zzalDetails"] as const,
+  all: ["zzal"] as const,
+  zzalDetailKey: () => [...zzalQueries.all, "zzalDetails"] as const,
   getZzalDetail: (imageId: number) =>
     queryOptions({
       queryKey: [...zzalQueries.zzalDetailKey(), imageId] as const,
@@ -15,7 +15,7 @@ export const zzalQueries = {
         ...data,
       }),
     }),
-  homeZzalsKey: () => [...zzalQueries.all(), "homeZzals"] as const,
+  homeZzalsKey: () => [...zzalQueries.all, "homeZzals"] as const,
   getHomeZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
       queryKey: [...zzalQueries.homeZzalsKey(), selectedTags] as const,
@@ -27,7 +27,7 @@ export const zzalQueries = {
       },
       initialPageParam: 0,
     }),
-  myLikedZzalsKey: () => [...zzalQueries.all(), "likedZzals"] as const,
+  myLikedZzalsKey: () => [...zzalQueries.all, "likedZzals"] as const,
   getMyLikedZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
       queryKey: [...zzalQueries.myLikedZzalsKey(), selectedTags] as const,
@@ -39,7 +39,7 @@ export const zzalQueries = {
       },
       initialPageParam: 0,
     }),
-  myUploadedZzlasKey: () => [...zzalQueries.all(), "uploadedZzals"] as const,
+  myUploadedZzlasKey: () => [...zzalQueries.all, "uploadedZzals"] as const,
   getMyUploadedZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
       queryKey: [...zzalQueries.myUploadedZzlasKey(), selectedTags] as const,

--- a/src/hooks/api/zzal/queryKeyFactories.ts
+++ b/src/hooks/api/zzal/queryKeyFactories.ts
@@ -39,10 +39,10 @@ export const zzalQueries = {
       },
       initialPageParam: 0,
     }),
-  myUploadedZzlasKey: () => [...zzalQueries.all, "uploadedZzals"] as const,
+  myUploadedZzalsKey: () => [...zzalQueries.all, "uploadedZzals"] as const,
   getMyUploadedZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
-      queryKey: [...zzalQueries.myUploadedZzlasKey(), selectedTags] as const,
+      queryKey: [...zzalQueries.myUploadedZzalsKey(), selectedTags] as const,
       queryFn: ({ pageParam = 0 }) => getMyUploadedZzals({ page: pageParam, selectedTags }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;

--- a/src/hooks/api/zzal/queryKeyFactories.ts
+++ b/src/hooks/api/zzal/queryKeyFactories.ts
@@ -1,0 +1,54 @@
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
+import { getHomeZzals, getMyLikedZzals, getMyUploadedZzals, getZzalDetails } from "@/apis/zzal";
+
+export const zzalQueries = {
+  all: () => ["zzal"] as const,
+  zzalDetailKey: () => [...zzalQueries.all(), "zzalDetails"] as const,
+  getZzalDetail: (imageId: number) =>
+    queryOptions({
+      queryKey: [...zzalQueries.zzalDetailKey(), imageId] as const,
+      queryFn: () => getZzalDetails(imageId),
+      select: (data) => ({
+        isLiked: data.imageLikeYn,
+        imageUrl: data.imgUrl,
+        tagNames: data.tags.map((tag) => tag.tagName),
+        ...data,
+      }),
+    }),
+  homeZzalsKey: () => [...zzalQueries.all(), "homeZzals"] as const,
+  getHomeZzals: (selectedTags: string[]) =>
+    infiniteQueryOptions({
+      queryKey: [...zzalQueries.homeZzalsKey(), selectedTags] as const,
+      queryFn: ({ pageParam = 0 }) => getHomeZzals({ page: pageParam, selectedTags }),
+      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+        if (!lastPage) return;
+
+        return lastPageParam + 1;
+      },
+      initialPageParam: 0,
+    }),
+  myLikedZzalsKey: () => [...zzalQueries.all(), "likedZzals"] as const,
+  getMyLikedZzals: (selectedTags: string[]) =>
+    infiniteQueryOptions({
+      queryKey: [...zzalQueries.myLikedZzalsKey(), selectedTags] as const,
+      queryFn: ({ pageParam = 0 }) => getMyLikedZzals({ page: pageParam, selectedTags }),
+      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+        if (!lastPage) return;
+
+        return lastPageParam + 1;
+      },
+      initialPageParam: 0,
+    }),
+  myUploadedZzlasKey: () => [...zzalQueries.all(), "uploadedZzals"] as const,
+  getMyUploadedZzals: (selectedTags: string[]) =>
+    infiniteQueryOptions({
+      queryKey: [...zzalQueries.myUploadedZzlasKey(), selectedTags] as const,
+      queryFn: ({ pageParam = 0 }) => getMyUploadedZzals({ page: pageParam, selectedTags }),
+      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+        if (!lastPage) return;
+
+        return lastPageParam + 1;
+      },
+      initialPageParam: 0,
+    }),
+};


### PR DESCRIPTION
## 📝 작업 내용

TanStack Query의 쿼리들을 효율적으로 관리하고 유지보수 할 수 있도록 `짤, 인증, 채팅, 태그, 신고` 관련 쿼리를 `QueryOptions/InfiniteQueryOptions`를 사용하여 `co-location` 하는 방식으로 수정하였습니다.

- 현재 아직 Next.js로 마이그레이션 작업이 진행중이라 수정한 쿼리문을 각각의 사용처에 적용하지는 않았습니다. 
- 또한 `QueryOptions/InfiniteQueryOptions`을 사용함으로써 중복되는 파일들을 아직 제거하지 않았습니다. 아직 도메인 변경 후 변경된 도메인 주소가 배포에 반영되지 않아 API Request를 테스트해 볼 수 없고, 마이그레이션 하는데도 혼선이 있을 것 같아 그대로 두었습니다.

추후, NextJS 마이그레이션과 변경된 도메인이 반영이 되면, 그때 중복되는 코드들을 지우고 구현한 `QueryKeyFactories`를 사용하도록 페이지들을 수정할 예정입니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- `hooks/api` 각각의 파일 내에 `queryKeyFactories`라는 네이밍을 지었는데 네이밍이 적절한지 궁금합니다.
- `queryKeyFactories` 내에 정의된 `queryKey`와 `api Request` 네이미잉 적절한지 궁금합니다.

# 📍 기타 (선택)

> 다른 분들이 참고해야할 사항이 있다면 작성해주세요

close #249 
