### PR TITLE
[#254] Modify: query factory 수정

### DIFF
--- a/src/hooks/api/auth/queryKeyFactories.ts
+++ b/src/hooks/api/auth/queryKeyFactories.ts
@@ -1,18 +1,12 @@
 import { queryOptions } from "@tanstack/react-query";
 import { getUserInformation } from "@/apis/auth";
 
-const authQueryKeys = {
-  all: () => ["auth"],
-  usersInformation: () => [...authQueryKeys.all(), "userInformation"],
-  userInformation: (refreshToken: string) => [...authQueryKeys.usersInformation(), refreshToken],
-};
-
 const authQueries = {
-  all: () => authQueryKeys.all(),
-  usersInformation: () => authQueryKeys.usersInformation(),
+  all: () => ["auth"],
+  usersInformation: () => [...authQueries.all(), "userInformation"],
   userInformation: (refreshToken: string) =>
     queryOptions({
-      queryKey: authQueryKeys.userInformation(refreshToken),
+      queryKey: [...authQueries.usersInformation(), refreshToken],
       queryFn: getUserInformation,
       enabled: !!refreshToken,
     }),

--- a/src/hooks/api/auth/queryKeyFactories.ts
+++ b/src/hooks/api/auth/queryKeyFactories.ts
@@ -1,13 +1,21 @@
 import { queryOptions } from "@tanstack/react-query";
 import { getUserInformation } from "@/apis/auth";
 
-export const authQueries = {
+const authQueryKeys = {
   all: () => ["auth"],
-  usersInformation: () => [...authQueries.all(), "userInformation"],
+  usersInformation: () => [...authQueryKeys.all(), "userInformation"],
+  userInformation: (refreshToken: string) => [...authQueryKeys.usersInformation(), refreshToken],
+};
+
+const authQueries = {
+  all: () => authQueryKeys.all(),
+  usersInformation: () => authQueryKeys.usersInformation(),
   userInformation: (refreshToken: string) =>
     queryOptions({
-      queryKey: [...authQueries.usersInformation(), refreshToken],
+      queryKey: authQueryKeys.userInformation(refreshToken),
       queryFn: getUserInformation,
       enabled: !!refreshToken,
     }),
 };
+
+export default authQueries;

--- a/src/hooks/api/auth/queryKeyFactories.ts
+++ b/src/hooks/api/auth/queryKeyFactories.ts
@@ -2,11 +2,11 @@ import { queryOptions } from "@tanstack/react-query";
 import { getUserInformation } from "@/apis/auth";
 
 export const authQueries = {
-  all: ["auth"] as const,
-  userInformationKey: () => [...authQueries.all, "userInfomation"] as const,
-  getUserInformation: (refreshToken: string) =>
+  all: () => ["auth"],
+  usersInformation: () => [...authQueries.all(), "userInformation"],
+  userInformation: (refreshToken: string) =>
     queryOptions({
-      queryKey: [...authQueries.userInformationKey()] as const,
+      queryKey: [...authQueries.usersInformation(), refreshToken],
       queryFn: getUserInformation,
       enabled: !!refreshToken,
     }),

--- a/src/hooks/api/chat/queryKeyFactories.ts
+++ b/src/hooks/api/chat/queryKeyFactories.ts
@@ -1,16 +1,11 @@
 import { infiniteQueryOptions } from "@tanstack/react-query";
 import { getChat } from "@/apis/chat";
 
-const chatQueryKeys = {
-  all: () => ["chat"],
-  messages: () => [...chatQueryKeys.all(), "message"],
-};
-
 const chatQueries = {
-  all: () => chatQueryKeys.all(),
+  all: () => ["chat"],
   messages: () =>
     infiniteQueryOptions({
-      queryKey: chatQueryKeys.messages(),
+      queryKey: [...chatQueries.all(), "message"],
       queryFn: async ({ pageParam = 0 }) => await getChat(pageParam),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (lastPage.length === 0) return;

--- a/src/hooks/api/chat/queryKeyFactories.ts
+++ b/src/hooks/api/chat/queryKeyFactories.ts
@@ -2,11 +2,10 @@ import { infiniteQueryOptions } from "@tanstack/react-query";
 import { getChat } from "@/apis/chat";
 
 export const chatQueries = {
-  all: ["chat"] as const,
-  chatListKey: () => [...chatQueries.all, "chatList"] as const,
-  getChatList: () =>
+  all: () => ["chat"],
+  messages: () =>
     infiniteQueryOptions({
-      queryKey: [...chatQueries.chatListKey()] as const,
+      queryKey: [...chatQueries.all(), "message"],
       queryFn: async ({ pageParam = 0 }) => await getChat(pageParam),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (lastPage.length === 0) return;

--- a/src/hooks/api/chat/queryKeyFactories.ts
+++ b/src/hooks/api/chat/queryKeyFactories.ts
@@ -1,11 +1,16 @@
 import { infiniteQueryOptions } from "@tanstack/react-query";
 import { getChat } from "@/apis/chat";
 
-export const chatQueries = {
+const chatQueryKeys = {
   all: () => ["chat"],
+  messages: () => [...chatQueryKeys.all(), "message"],
+};
+
+const chatQueries = {
+  all: () => chatQueryKeys.all(),
   messages: () =>
     infiniteQueryOptions({
-      queryKey: [...chatQueries.all(), "message"],
+      queryKey: chatQueryKeys.messages(),
       queryFn: async ({ pageParam = 0 }) => await getChat(pageParam),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (lastPage.length === 0) return;
@@ -21,3 +26,5 @@ export const chatQueries = {
       refetchOnMount: false,
     }),
 };
+
+export default chatQueries;

--- a/src/hooks/api/report/queryKeyFactories.ts
+++ b/src/hooks/api/report/queryKeyFactories.ts
@@ -5,7 +5,7 @@ export const reportQueries = {
   all: () => ["report"],
   reports: () =>
     infiniteQueryOptions({
-      queryKey: [...reportQueries.all(), "report"],
+      queryKey: [...reportQueries.all(), "list"],
       queryFn: ({ pageParam = 0 }) => getReports(pageParam),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;

--- a/src/hooks/api/report/queryKeyFactories.ts
+++ b/src/hooks/api/report/queryKeyFactories.ts
@@ -1,11 +1,17 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { getReportDetails, getReports } from "@/apis/report";
 
-export const reportQueries = {
+const reportQueryKeys = {
   all: () => ["report"],
+  reports: () => [reportQueryKeys.all(), "list"],
+  report: (imageId: string) => [reportQueryKeys.reports(), imageId],
+};
+
+const reportQueries = {
+  all: () => reportQueryKeys.all(),
   reports: () =>
     infiniteQueryOptions({
-      queryKey: [...reportQueries.all(), "list"],
+      queryKey: reportQueryKeys.reports(),
       queryFn: ({ pageParam = 0 }) => getReports(pageParam),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;
@@ -16,7 +22,9 @@ export const reportQueries = {
     }),
   report: (imageId: string) =>
     queryOptions({
-      queryKey: [...reportQueries.reports().queryKey, imageId],
+      queryKey: reportQueryKeys.report(imageId),
       queryFn: () => getReportDetails(imageId),
     }),
 };
+
+export default reportQueries;

--- a/src/hooks/api/report/queryKeyFactories.ts
+++ b/src/hooks/api/report/queryKeyFactories.ts
@@ -1,17 +1,11 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { getReportDetails, getReports } from "@/apis/report";
 
-const reportQueryKeys = {
-  all: () => ["report"],
-  reports: () => [reportQueryKeys.all(), "list"],
-  report: (imageId: string) => [reportQueryKeys.reports(), imageId],
-};
-
 const reportQueries = {
-  all: () => reportQueryKeys.all(),
+  all: () => ["report"],
   reports: () =>
     infiniteQueryOptions({
-      queryKey: reportQueryKeys.reports(),
+      queryKey: [...reportQueries.all(), "list"],
       queryFn: ({ pageParam = 0 }) => getReports(pageParam),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;
@@ -22,7 +16,7 @@ const reportQueries = {
     }),
   report: (imageId: string) =>
     queryOptions({
-      queryKey: reportQueryKeys.report(imageId),
+      queryKey: [...reportQueries.reports().queryKey, imageId],
       queryFn: () => getReportDetails(imageId),
     }),
 };

--- a/src/hooks/api/report/queryKeyFactories.ts
+++ b/src/hooks/api/report/queryKeyFactories.ts
@@ -2,11 +2,10 @@ import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { getReportDetails, getReports } from "@/apis/report";
 
 export const reportQueries = {
-  all: ["report"] as const,
-  reportListKey: () => [...reportQueries.all, "reportList"] as const,
-  getReportList: () =>
+  all: () => ["report"],
+  reports: () =>
     infiniteQueryOptions({
-      queryKey: [...reportQueries.reportListKey()] as const,
+      queryKey: [...reportQueries.all(), "report"],
       queryFn: ({ pageParam = 0 }) => getReports(pageParam),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;
@@ -15,10 +14,9 @@ export const reportQueries = {
       },
       initialPageParam: 0,
     }),
-  reportDetailKey: () => [...reportQueries.all, "reportDetail"] as const,
-  getReportDetail: (imageId: string) =>
+  report: (imageId: string) =>
     queryOptions({
-      queryKey: [...reportQueries.reportDetailKey(), imageId],
+      queryKey: [...reportQueries.reports().queryKey, imageId],
       queryFn: () => getReportDetails(imageId),
     }),
 };

--- a/src/hooks/api/tag/queryKeyFactories.ts
+++ b/src/hooks/api/tag/queryKeyFactories.ts
@@ -7,48 +7,37 @@ import {
   getTopTagsFromUploaded,
 } from "@/apis/tag";
 
-const tagQueryKeys = {
-  all: () => ["tags"],
-  searchResults: () => [...tagQueryKeys.all(), "search"],
-  searchResult: (tag: string) => [...tagQueryKeys.searchResults(), tag],
-  popularTags: () => [...tagQueryKeys.all(), "popularTags"],
-  topTags: () => [...tagQueryKeys.all(), "topTags"],
-  topTagsFromHome: () => [...tagQueryKeys.topTags(), "home"],
-  topTagsFromLiked: () => [...tagQueryKeys.topTags(), "liked"],
-  topTagsFromUploaded: () => [...tagQueryKeys.topTags(), "uploaded"],
-};
-
 const tagQueries = {
-  all: () => tagQueryKeys.all(),
-  searchResults: () => tagQueryKeys.searchResults(),
+  all: () => ["tags"],
+  searchResults: () => [...tagQueries.all(), "search"],
   searchResult: (tag: string) => {
     const MAX_TAG_RESPONSE_COUNT = 10;
 
     return queryOptions({
-      queryKey: tagQueryKeys.searchResult(tag),
+      queryKey: [...tagQueries.searchResults(), tag],
       queryFn: () => getSearchTag(tag),
       select: (tags) => tags.filter((_tag, index) => index < MAX_TAG_RESPONSE_COUNT),
     });
   },
   popularTags: () =>
     queryOptions({
-      queryKey: tagQueryKeys.popularTags(),
+      queryKey: [...tagQueries.all(), "popularTags"],
       queryFn: getPopularTags,
     }),
-  topTags: () => tagQueryKeys.topTags(),
+  topTags: () => [...tagQueries.all(), "topTags"],
   topTagsFromHome: () =>
     queryOptions({
-      queryKey: tagQueryKeys.topTagsFromHome(),
+      queryKey: [...tagQueries.topTags(), "home"],
       queryFn: getTopTagsFromHome,
     }),
   topTagsFromLiked: () =>
     queryOptions({
-      queryKey: tagQueryKeys.topTagsFromLiked(),
+      queryKey: [...tagQueries.topTags(), "liked"],
       queryFn: getTopTagsFromLiked,
     }),
   topTagsFromUploaded: () =>
     queryOptions({
-      queryKey: tagQueryKeys.topTagsFromUploaded(),
+      queryKey: [...tagQueries.topTags(), "uploaded"],
       queryFn: getTopTagsFromUploaded,
     }),
 };

--- a/src/hooks/api/tag/queryKeyFactories.ts
+++ b/src/hooks/api/tag/queryKeyFactories.ts
@@ -7,37 +7,50 @@ import {
   getTopTagsFromUploaded,
 } from "@/apis/tag";
 
-export const tagQueries = {
+const tagQueryKeys = {
   all: () => ["tags"],
-  searchResults: () => [...tagQueries.all(), "search"],
+  searchResults: () => [...tagQueryKeys.all(), "search"],
+  searchResult: (tag: string) => [...tagQueryKeys.searchResults(), tag],
+  popularTags: () => [...tagQueryKeys.all(), "popularTags"],
+  topTags: () => [...tagQueryKeys.all(), "topTags"],
+  topTagsFromHome: () => [...tagQueryKeys.topTags(), "home"],
+  topTagsFromLiked: () => [...tagQueryKeys.topTags(), "liked"],
+  topTagsFromUploaded: () => [...tagQueryKeys.topTags(), "uploaded"],
+};
+
+const tagQueries = {
+  all: () => tagQueryKeys.all(),
+  searchResults: () => tagQueryKeys.searchResults(),
   searchResult: (tag: string) => {
     const MAX_TAG_RESPONSE_COUNT = 10;
 
     return queryOptions({
-      queryKey: [...tagQueries.searchResults(), tag],
+      queryKey: tagQueryKeys.searchResult(tag),
       queryFn: () => getSearchTag(tag),
       select: (tags) => tags.filter((_tag, index) => index < MAX_TAG_RESPONSE_COUNT),
     });
   },
   popularTags: () =>
     queryOptions({
-      queryKey: [...tagQueries.all(), "popularTags"],
+      queryKey: tagQueryKeys.popularTags(),
       queryFn: getPopularTags,
     }),
-  topTags: () => [...tagQueries.all(), "topTags"],
-  getTopTagsFromHome: () =>
+  topTags: () => tagQueryKeys.topTags(),
+  topTagsFromHome: () =>
     queryOptions({
-      queryKey: [...tagQueries.topTags(), "home"],
+      queryKey: tagQueryKeys.topTagsFromHome(),
       queryFn: getTopTagsFromHome,
     }),
   topTagsFromLiked: () =>
     queryOptions({
-      queryKey: [...tagQueries.topTags(), "liked"],
+      queryKey: tagQueryKeys.topTagsFromLiked(),
       queryFn: getTopTagsFromLiked,
     }),
   topTagsFromUploaded: () =>
     queryOptions({
-      queryKey: [...tagQueries.topTags(), "uploaded"],
+      queryKey: tagQueryKeys.topTagsFromUploaded(),
       queryFn: getTopTagsFromUploaded,
     }),
 };
+
+export default tagQueries;

--- a/src/hooks/api/tag/queryKeyFactories.ts
+++ b/src/hooks/api/tag/queryKeyFactories.ts
@@ -8,39 +8,36 @@ import {
 } from "@/apis/tag";
 
 export const tagQueries = {
-  all: ["tag"] as const,
-  tagListKey: () => [...tagQueries.all, "tagList"] as const,
-  getTagList: (tag: string) => {
+  all: () => ["tags"],
+  searchResults: () => [...tagQueries.all(), "search"],
+  searchResult: (tag: string) => {
     const MAX_TAG_RESPONSE_COUNT = 10;
 
     return queryOptions({
-      queryKey: [...tagQueries.tagListKey(), tag] as const,
+      queryKey: [...tagQueries.searchResults(), tag],
       queryFn: () => getSearchTag(tag),
       select: (tags) => tags.filter((_tag, index) => index < MAX_TAG_RESPONSE_COUNT),
     });
   },
-  popularTagsKey: () => [...tagQueries.all, "popularTags"] as const,
-  getPopularTags: () =>
+  popularTags: () =>
     queryOptions({
-      queryKey: [...tagQueries.popularTagsKey()] as const,
+      queryKey: [...tagQueries.all(), "popularTags"],
       queryFn: getPopularTags,
     }),
-  topTagsFromHomeKey: () => [...tagQueries.all, "topTagsFromHome"] as const,
+  topTags: () => [...tagQueries.all(), "topTags"],
   getTopTagsFromHome: () =>
     queryOptions({
-      queryKey: [...tagQueries.topTagsFromHomeKey()] as const,
+      queryKey: [...tagQueries.topTags(), "home"],
       queryFn: getTopTagsFromHome,
     }),
-  topTagsFromLikedKey: () => [...tagQueries.all, "topTagsFromLiked"] as const,
-  getTopTagsFromLiked: () =>
+  topTagsFromLiked: () =>
     queryOptions({
-      queryKey: [...tagQueries.topTagsFromLikedKey()] as const,
+      queryKey: [...tagQueries.topTags(), "liked"],
       queryFn: getTopTagsFromLiked,
     }),
-  topTagsFromUploadedKey: () => [...tagQueries.all, "topTagsFromUploaded"] as const,
-  getTopTagsFromUploaded: () =>
+  topTagsFromUploaded: () =>
     queryOptions({
-      queryKey: [...tagQueries.topTagsFromUploadedKey()] as const,
+      queryKey: [...tagQueries.topTags(), "uploaded"],
       queryFn: getTopTagsFromUploaded,
     }),
 };

--- a/src/hooks/api/zzal/queryKeyFactories.ts
+++ b/src/hooks/api/zzal/queryKeyFactories.ts
@@ -15,9 +15,10 @@ export const zzalQueries = {
         ...data,
       }),
     }),
-  homeZzals: (selectedTags: string[]) =>
+  homeZzals: () => [...zzalQueries.all(), "home"],
+  selectedHomeZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
-      queryKey: [...zzalQueries.all(), "home", selectedTags],
+      queryKey: [...zzalQueries.homeZzals(), selectedTags],
       queryFn: ({ pageParam = 0 }) => getHomeZzals({ page: pageParam, selectedTags }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;
@@ -26,9 +27,10 @@ export const zzalQueries = {
       },
       initialPageParam: 0,
     }),
-  myLikedZzals: (selectedTags: string[]) =>
+  myLikedZzals: () => [...zzalQueries.all(), "liked"],
+  selectedMyLikedZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
-      queryKey: [...zzalQueries.all(), "liked", selectedTags],
+      queryKey: [...zzalQueries.myLikedZzals(), selectedTags],
       queryFn: ({ pageParam = 0 }) => getMyLikedZzals({ page: pageParam, selectedTags }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;
@@ -37,9 +39,10 @@ export const zzalQueries = {
       },
       initialPageParam: 0,
     }),
-  myUploadedZzals: (selectedTags: string[]) =>
+  myUploadedZzals: () => [...zzalQueries.all(), "uploaded"],
+  selectedMyUploadedZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
-      queryKey: [...zzalQueries.all(), "uploaded", selectedTags],
+      queryKey: [...zzalQueries.myUploadedZzals(), selectedTags],
       queryFn: ({ pageParam = 0 }) => getMyUploadedZzals({ page: pageParam, selectedTags }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;

--- a/src/hooks/api/zzal/queryKeyFactories.ts
+++ b/src/hooks/api/zzal/queryKeyFactories.ts
@@ -1,27 +1,12 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { getHomeZzals, getMyLikedZzals, getMyUploadedZzals, getZzalDetails } from "@/apis/zzal";
 
-const zzalQueryKeys = {
-  all: () => ["zzal"],
-  details: () => [...zzalQueryKeys.all(), "detail"],
-  detail: (imageId: number) => [...zzalQueryKeys.details(), imageId],
-  homeZzals: () => [...zzalQueryKeys.all(), "home"],
-  selectedHomeZzals: (selectedTags: string[]) => [...zzalQueryKeys.homeZzals(), selectedTags],
-  myLikedZzals: () => [...zzalQueryKeys.all(), "liked"],
-  selectedMyLikedZzals: (selectedTags: string[]) => [...zzalQueryKeys.myLikedZzals(), selectedTags],
-  myUploadedZzals: () => [...zzalQueryKeys.all(), "uploaded"],
-  selectedMyUploadedZzals: (selectedTags: string[]) => [
-    ...zzalQueryKeys.myUploadedZzals(),
-    selectedTags,
-  ],
-};
-
 const zzalQueries = {
-  all: () => zzalQueryKeys.all(),
-  details: () => zzalQueryKeys.details(),
+  all: () => ["zzal"],
+  details: () => [...zzalQueries.all(), "detail"],
   detail: (imageId: number) =>
     queryOptions({
-      queryKey: zzalQueryKeys.detail(imageId),
+      queryKey: [...zzalQueries.details(), imageId],
       queryFn: () => getZzalDetails(imageId),
       select: (data) => ({
         isLiked: data.imageLikeYn,
@@ -30,10 +15,10 @@ const zzalQueries = {
         ...data,
       }),
     }),
-  homeZzals: () => zzalQueryKeys.homeZzals(),
+  homeZzals: () => [...zzalQueries.all(), "home"],
   selectedHomeZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
-      queryKey: zzalQueryKeys.selectedHomeZzals(selectedTags),
+      queryKey: [...zzalQueries.homeZzals(), selectedTags],
       queryFn: ({ pageParam = 0 }) => getHomeZzals({ page: pageParam, selectedTags }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;
@@ -42,10 +27,10 @@ const zzalQueries = {
       },
       initialPageParam: 0,
     }),
-  myLikedZzals: () => zzalQueryKeys.myLikedZzals(),
+  myLikedZzals: () => [...zzalQueries.all(), "liked"],
   selectedMyLikedZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
-      queryKey: zzalQueryKeys.selectedMyLikedZzals(selectedTags),
+      queryKey: [...zzalQueries.myLikedZzals(), selectedTags],
       queryFn: ({ pageParam = 0 }) => getMyLikedZzals({ page: pageParam, selectedTags }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;
@@ -54,10 +39,10 @@ const zzalQueries = {
       },
       initialPageParam: 0,
     }),
-  myUploadedZzals: () => zzalQueryKeys.myUploadedZzals(),
+  myUploadedZzals: () => [...zzalQueries.all(), "uploaded"],
   selectedMyUploadedZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
-      queryKey: zzalQueryKeys.selectedMyUploadedZzals(selectedTags),
+      queryKey: [...zzalQueries.myUploadedZzals(), selectedTags],
       queryFn: ({ pageParam = 0 }) => getMyUploadedZzals({ page: pageParam, selectedTags }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;

--- a/src/hooks/api/zzal/queryKeyFactories.ts
+++ b/src/hooks/api/zzal/queryKeyFactories.ts
@@ -1,12 +1,27 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { getHomeZzals, getMyLikedZzals, getMyUploadedZzals, getZzalDetails } from "@/apis/zzal";
 
-export const zzalQueries = {
+const zzalQueryKeys = {
   all: () => ["zzal"],
-  details: () => [...zzalQueries.all(), "detail"],
+  details: () => [...zzalQueryKeys.all(), "detail"],
+  detail: (imageId: number) => [...zzalQueryKeys.details(), imageId],
+  homeZzals: () => [...zzalQueryKeys.all(), "home"],
+  selectedHomeZzals: (selectedTags: string[]) => [...zzalQueryKeys.homeZzals(), selectedTags],
+  myLikedZzals: () => [...zzalQueryKeys.all(), "liked"],
+  selectedMyLikedZzals: (selectedTags: string[]) => [...zzalQueryKeys.myLikedZzals(), selectedTags],
+  myUploadedZzals: () => [...zzalQueryKeys.all(), "uploaded"],
+  selectedMyUploadedZzals: (selectedTags: string[]) => [
+    ...zzalQueryKeys.myUploadedZzals(),
+    selectedTags,
+  ],
+};
+
+const zzalQueries = {
+  all: () => zzalQueryKeys.all(),
+  details: () => zzalQueryKeys.details(),
   detail: (imageId: number) =>
     queryOptions({
-      queryKey: [...zzalQueries.details(), imageId],
+      queryKey: zzalQueryKeys.detail(imageId),
       queryFn: () => getZzalDetails(imageId),
       select: (data) => ({
         isLiked: data.imageLikeYn,
@@ -15,10 +30,10 @@ export const zzalQueries = {
         ...data,
       }),
     }),
-  homeZzals: () => [...zzalQueries.all(), "home"],
+  homeZzals: () => zzalQueryKeys.homeZzals(),
   selectedHomeZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
-      queryKey: [...zzalQueries.homeZzals(), selectedTags],
+      queryKey: zzalQueryKeys.selectedHomeZzals(selectedTags),
       queryFn: ({ pageParam = 0 }) => getHomeZzals({ page: pageParam, selectedTags }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;
@@ -27,10 +42,10 @@ export const zzalQueries = {
       },
       initialPageParam: 0,
     }),
-  myLikedZzals: () => [...zzalQueries.all(), "liked"],
+  myLikedZzals: () => zzalQueryKeys.myLikedZzals(),
   selectedMyLikedZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
-      queryKey: [...zzalQueries.myLikedZzals(), selectedTags],
+      queryKey: zzalQueryKeys.selectedMyLikedZzals(selectedTags),
       queryFn: ({ pageParam = 0 }) => getMyLikedZzals({ page: pageParam, selectedTags }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;
@@ -39,10 +54,10 @@ export const zzalQueries = {
       },
       initialPageParam: 0,
     }),
-  myUploadedZzals: () => [...zzalQueries.all(), "uploaded"],
+  myUploadedZzals: () => zzalQueryKeys.myUploadedZzals(),
   selectedMyUploadedZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
-      queryKey: [...zzalQueries.myUploadedZzals(), selectedTags],
+      queryKey: zzalQueryKeys.selectedMyUploadedZzals(selectedTags),
       queryFn: ({ pageParam = 0 }) => getMyUploadedZzals({ page: pageParam, selectedTags }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;
@@ -52,3 +67,5 @@ export const zzalQueries = {
       initialPageParam: 0,
     }),
 };
+
+export default zzalQueries;

--- a/src/hooks/api/zzal/queryKeyFactories.ts
+++ b/src/hooks/api/zzal/queryKeyFactories.ts
@@ -2,11 +2,11 @@ import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { getHomeZzals, getMyLikedZzals, getMyUploadedZzals, getZzalDetails } from "@/apis/zzal";
 
 export const zzalQueries = {
-  all: ["zzal"] as const,
-  zzalDetailKey: () => [...zzalQueries.all, "zzalDetails"] as const,
-  getZzalDetail: (imageId: number) =>
+  all: () => ["zzal"],
+  details: () => [...zzalQueries.all(), "detail"],
+  detail: (imageId: number) =>
     queryOptions({
-      queryKey: [...zzalQueries.zzalDetailKey(), imageId] as const,
+      queryKey: [...zzalQueries.details(), imageId],
       queryFn: () => getZzalDetails(imageId),
       select: (data) => ({
         isLiked: data.imageLikeYn,
@@ -15,10 +15,9 @@ export const zzalQueries = {
         ...data,
       }),
     }),
-  homeZzalsKey: () => [...zzalQueries.all, "homeZzals"] as const,
-  getHomeZzals: (selectedTags: string[]) =>
+  homeZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
-      queryKey: [...zzalQueries.homeZzalsKey(), selectedTags] as const,
+      queryKey: [...zzalQueries.all(), "home", selectedTags],
       queryFn: ({ pageParam = 0 }) => getHomeZzals({ page: pageParam, selectedTags }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;
@@ -27,10 +26,9 @@ export const zzalQueries = {
       },
       initialPageParam: 0,
     }),
-  myLikedZzalsKey: () => [...zzalQueries.all, "likedZzals"] as const,
-  getMyLikedZzals: (selectedTags: string[]) =>
+  myLikedZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
-      queryKey: [...zzalQueries.myLikedZzalsKey(), selectedTags] as const,
+      queryKey: [...zzalQueries.all(), "liked", selectedTags],
       queryFn: ({ pageParam = 0 }) => getMyLikedZzals({ page: pageParam, selectedTags }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;
@@ -39,10 +37,9 @@ export const zzalQueries = {
       },
       initialPageParam: 0,
     }),
-  myUploadedZzalsKey: () => [...zzalQueries.all, "uploadedZzals"] as const,
-  getMyUploadedZzals: (selectedTags: string[]) =>
+  myUploadedZzals: (selectedTags: string[]) =>
     infiniteQueryOptions({
-      queryKey: [...zzalQueries.myUploadedZzalsKey(), selectedTags] as const,
+      queryKey: [...zzalQueries.all(), "uploaded", selectedTags],
       queryFn: ({ pageParam = 0 }) => getMyUploadedZzals({ page: pageParam, selectedTags }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage) return;


### PR DESCRIPTION
# [#254] Modify: query factory 수정

## 📝 작업 내용

> query factory를 수정하여 @tanstack/react-query의 query key 및 query function까지 factory 패턴으로 관리하도록 수정합니다. 

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- query key 네이밍을 수정했습니다. [The Query Options API
](https://tkdodo.eu/blog/the-query-options-api)에서 사용하는 예시를 참고하여 쿼리 키 간의 계층적인 관계가 성립되도록 수정했습니다. 네이밍 및 쿼리 간의 관계에 대한 피드백 부탁드립니다.


# 📍 기타 (선택)

[The Query Options API
](https://tkdodo.eu/blog/the-query-options-api)

close #254
