### PR TITLE
[#257] Package: MSW 설치 및 세팅 + 로그인을 제외한 기존 API mocking 핸들러 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,9 +66,15 @@
     "eslint-plugin-unused-imports": "^3.0.0",
     "husky": "^8.0.3",
     "lint-staged": "^15.2.2",
+    "msw": "^2.4.2",
     "postcss": "^8.4.35",
     "prettier-plugin-tailwindcss": "^0.5.11",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^18.6.0
-        version: 18.6.0(@types/node@20.12.12)(typescript@5.3.3)
+        version: 18.6.0(@types/node@22.5.4)(typescript@5.3.3)
       '@commitlint/config-conventional':
         specifier: ^18.6.0
         version: 18.6.0
@@ -147,6 +147,9 @@ importers:
       lint-staged:
         specifier: ^15.2.2
         version: 15.2.2
+      msw:
+        specifier: ^2.4.2
+        version: 2.4.2(graphql@16.9.0)(typescript@5.3.3)
       postcss:
         specifier: ^8.4.35
         version: 8.4.35
@@ -889,6 +892,15 @@ packages:
     resolution: {integrity: sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==}
     engines: {node: '>=6.9.0'}
 
+  '@bundled-es-modules/cookie@2.0.0':
+    resolution: {integrity: sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==}
+
+  '@bundled-es-modules/statuses@1.0.1':
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+
+  '@bundled-es-modules/tough-cookie@0.1.6':
+    resolution: {integrity: sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==}
+
   '@commitlint/cli@18.6.0':
     resolution: {integrity: sha512-FiH23cr9QG8VdfbmvJJZmdfHGVMCouOOAzoXZ3Cd7czGC52RbycwNt8YCI7SA69pAl+t30vh8LMaO/N+kcel6w==}
     engines: {node: '>=v18'}
@@ -987,6 +999,22 @@ packages:
   '@humanwhocodes/object-schema@2.0.2':
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
 
+  '@inquirer/confirm@3.2.0':
+    resolution: {integrity: sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==}
+    engines: {node: '>=18'}
+
+  '@inquirer/core@9.1.0':
+    resolution: {integrity: sha512-RZVfH//2ytTjmaBIzeKT1zefcQZzuruwkpTwwbe/i2jTl4o9M+iML5ChULzz6iw1Ok8iUBBsRCjY2IEbD8Ft4w==}
+    engines: {node: '>=18'}
+
+  '@inquirer/figures@1.0.5':
+    resolution: {integrity: sha512-79hP/VWdZ2UVc9bFGJnoQ/lQMpL74mGgzSYX1xUqCVk7/v73vJCMw1VuyWN1jGkZ9B3z7THAbySqGbCNefcjfA==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@1.5.3':
+    resolution: {integrity: sha512-xUQ14WQGR/HK5ei+2CvgcwoH9fQ4PgPGmVFSN0pc1+fVyDL3MREhyAY7nxEErSu6CkllBM3D7e3e+kOvtu+eIg==}
+    engines: {node: '>=18'}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1022,6 +1050,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@mswjs/interceptors@0.29.1':
+    resolution: {integrity: sha512-3rDakgJZ77+RiQUuSK69t1F0m8BQKA8Vh5DCS5V0DWvNY67zob2JhhQrhCO0AKLGINTRSFd1tBaHcJTkhefoSw==}
+    engines: {node: '>=18'}
 
   '@next/env@14.2.5':
     resolution: {integrity: sha512-/zZGkrTOsraVfYjGP8uM0p6r0BDT6xWpkjdVbcz66PJVSpwXX3yNiRycxAuDfBKGWBrZBXRuK/YVlkNgxHGwmA==}
@@ -1100,6 +1132,15 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@opentelemetry/api-logs@0.52.1':
     resolution: {integrity: sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==}
@@ -1583,6 +1624,9 @@ packages:
   '@types/connect@3.4.36':
     resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
 
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -1604,11 +1648,17 @@ packages:
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
+  '@types/mute-stream@0.0.4':
+    resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
+
   '@types/mysql@2.15.22':
     resolution: {integrity: sha512-wK1pzsJVVAjYCSZWQoWHziQZbNggXFDUEIGf54g4ZM/ERuP86uGdWeKZWMYlqTPMZfHJJvLPyogXGvCOg87yLQ==}
 
   '@types/node@20.12.12':
     resolution: {integrity: sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==}
+
+  '@types/node@22.5.4':
+    resolution: {integrity: sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -1639,6 +1689,15 @@ packages:
 
   '@types/sockjs-client@1.5.4':
     resolution: {integrity: sha512-zk+uFZeWyvJ5ZFkLIwoGA/DfJ+pYzcZ8eH4H/EILCm2OBZyHH6Hkdna1/UWL/CFruh5wj6ES7g75SvUB0VsH5w==}
+
+  '@types/statuses@2.0.5':
+    resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/wrap-ansi@3.0.0':
+    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
   '@typescript-eslint/eslint-plugin@6.21.0':
     resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
@@ -1790,6 +1849,10 @@ packages:
 
   ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
 
   ansi-escapes@6.2.0:
     resolution: {integrity: sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==}
@@ -2003,9 +2066,17 @@ packages:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -2077,6 +2148,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@0.5.0:
+    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+    engines: {node: '>= 0.6'}
 
   core-js-compat@3.37.1:
     resolution: {integrity: sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==}
@@ -2627,6 +2702,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphql@16.9.0:
+    resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
@@ -2660,6 +2739,9 @@ packages:
   hasown@2.0.0:
     resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
     engines: {node: '>= 0.4'}
+
+  headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -2792,6 +2874,9 @@ packages:
   is-negative-zero@2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
@@ -3149,6 +3234,23 @@ packages:
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
+  msw@2.4.2:
+    resolution: {integrity: sha512-GImSQGhn19czhVpxPdiUDK8CMZ6jbBcvOhzfJd8KFErjEER2wDKWs1UYaetJs2GSNlAqt6heZYm7g3eLatTcog==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      graphql: '>= 16.8.x'
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      graphql:
+        optional: true
+      typescript:
+        optional: true
+
+  mute-stream@1.0.0:
+    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -3280,6 +3382,9 @@ packages:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
 
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -3333,6 +3438,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@6.2.2:
+    resolution: {integrity: sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3504,6 +3612,9 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  psl@1.9.0:
+    resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3777,9 +3888,16 @@ packages:
     resolution: {integrity: sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==}
     engines: {node: '>=6'}
 
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -3955,6 +4073,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -3989,6 +4111,10 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
 
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
   type-fest@0.6.0:
     resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
     engines: {node: '>=8'}
@@ -4004,6 +4130,10 @@ packages:
   type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
+
+  type-fest@4.26.0:
+    resolution: {integrity: sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==}
+    engines: {node: '>=16'}
 
   typed-array-buffer@1.0.1:
     resolution: {integrity: sha512-RSqu1UEuSlrBhHTWC8O9FnPjOduNs4M7rJ4pRKoEjtx1zUNOPN2sSXHLDX+Y2WPbHIxbvg4JFo2DNAEfPIKWoQ==}
@@ -4031,6 +4161,9 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -4046,6 +4179,10 @@ packages:
   unicode-property-aliases-ecmascript@2.1.0:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
+
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
 
   unplugin@1.0.1:
     resolution: {integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==}
@@ -4132,6 +4269,10 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -4180,6 +4321,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.2:
+    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
 
 snapshots:
 
@@ -5137,11 +5282,24 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
 
-  '@commitlint/cli@18.6.0(@types/node@20.12.12)(typescript@5.3.3)':
+  '@bundled-es-modules/cookie@2.0.0':
+    dependencies:
+      cookie: 0.5.0
+
+  '@bundled-es-modules/statuses@1.0.1':
+    dependencies:
+      statuses: 2.0.1
+
+  '@bundled-es-modules/tough-cookie@0.1.6':
+    dependencies:
+      '@types/tough-cookie': 4.0.5
+      tough-cookie: 4.1.4
+
+  '@commitlint/cli@18.6.0(@types/node@22.5.4)(typescript@5.3.3)':
     dependencies:
       '@commitlint/format': 18.6.0
       '@commitlint/lint': 18.6.0
-      '@commitlint/load': 18.6.0(@types/node@20.12.12)(typescript@5.3.3)
+      '@commitlint/load': 18.6.0(@types/node@22.5.4)(typescript@5.3.3)
       '@commitlint/read': 18.6.0
       '@commitlint/types': 18.6.0
       execa: 5.1.1
@@ -5190,7 +5348,7 @@ snapshots:
       '@commitlint/rules': 18.6.0
       '@commitlint/types': 18.6.0
 
-  '@commitlint/load@18.6.0(@types/node@20.12.12)(typescript@5.3.3)':
+  '@commitlint/load@18.6.0(@types/node@22.5.4)(typescript@5.3.3)':
     dependencies:
       '@commitlint/config-validator': 18.6.0
       '@commitlint/execute-rule': 18.4.4
@@ -5198,7 +5356,7 @@ snapshots:
       '@commitlint/types': 18.6.0
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.3.3)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@20.12.12)(cosmiconfig@8.3.6(typescript@5.3.3))(typescript@5.3.3)
+      cosmiconfig-typescript-loader: 5.0.0(@types/node@22.5.4)(cosmiconfig@8.3.6(typescript@5.3.3))(typescript@5.3.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -5284,6 +5442,33 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.2': {}
 
+  '@inquirer/confirm@3.2.0':
+    dependencies:
+      '@inquirer/core': 9.1.0
+      '@inquirer/type': 1.5.3
+
+  '@inquirer/core@9.1.0':
+    dependencies:
+      '@inquirer/figures': 1.0.5
+      '@inquirer/type': 1.5.3
+      '@types/mute-stream': 0.0.4
+      '@types/node': 22.5.4
+      '@types/wrap-ansi': 3.0.0
+      ansi-escapes: 4.3.2
+      cli-spinners: 2.9.2
+      cli-width: 4.1.0
+      mute-stream: 1.0.0
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+
+  '@inquirer/figures@1.0.5': {}
+
+  '@inquirer/type@1.5.3':
+    dependencies:
+      mute-stream: 1.0.0
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -5327,6 +5512,15 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  '@mswjs/interceptors@0.29.1':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
 
   '@next/env@14.2.5': {}
 
@@ -5378,6 +5572,15 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@opentelemetry/api-logs@0.52.1':
     dependencies:
@@ -6015,6 +6218,8 @@ snapshots:
     dependencies:
       '@types/node': 20.12.12
 
+  '@types/cookie@0.6.0': {}
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 8.56.10
@@ -6035,6 +6240,10 @@ snapshots:
 
   '@types/minimist@1.2.5': {}
 
+  '@types/mute-stream@0.0.4':
+    dependencies:
+      '@types/node': 22.5.4
+
   '@types/mysql@2.15.22':
     dependencies:
       '@types/node': 20.12.12
@@ -6042,6 +6251,10 @@ snapshots:
   '@types/node@20.12.12':
     dependencies:
       undici-types: 5.26.5
+
+  '@types/node@22.5.4':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -6074,6 +6287,12 @@ snapshots:
   '@types/shimmer@1.2.0': {}
 
   '@types/sockjs-client@1.5.4': {}
+
+  '@types/statuses@2.0.5': {}
+
+  '@types/tough-cookie@4.0.5': {}
+
+  '@types/wrap-ansi@3.0.0': {}
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3)':
     dependencies:
@@ -6286,6 +6505,10 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
+
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
 
   ansi-escapes@6.2.0:
     dependencies:
@@ -6536,10 +6759,14 @@ snapshots:
     dependencies:
       restore-cursor: 4.0.0
 
+  cli-spinners@2.9.2: {}
+
   cli-truncate@4.0.0:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.1.0
+
+  cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
 
@@ -6603,13 +6830,15 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@0.5.0: {}
+
   core-js-compat@3.37.1:
     dependencies:
       browserslist: 4.23.2
 
-  cosmiconfig-typescript-loader@5.0.0(@types/node@20.12.12)(cosmiconfig@8.3.6(typescript@5.3.3))(typescript@5.3.3):
+  cosmiconfig-typescript-loader@5.0.0(@types/node@22.5.4)(cosmiconfig@8.3.6(typescript@5.3.3))(typescript@5.3.3):
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 22.5.4
       cosmiconfig: 8.3.6(typescript@5.3.3)
       jiti: 1.21.0
       typescript: 5.3.3
@@ -7260,6 +7489,9 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphql@16.9.0:
+    optional: true
+
   hard-rejection@2.1.0: {}
 
   has-bigints@1.0.2: {}
@@ -7283,6 +7515,8 @@ snapshots:
   hasown@2.0.0:
     dependencies:
       function-bind: 1.1.2
+
+  headers-polyfill@4.0.3: {}
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -7410,6 +7644,8 @@ snapshots:
 
   is-negative-zero@2.0.2: {}
 
+  is-node-process@1.2.0: {}
+
   is-number-object@1.0.7:
     dependencies:
       has-tostringtag: 1.0.2
@@ -7494,7 +7730,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 22.5.4
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -7732,6 +7968,30 @@ snapshots:
 
   ms@2.1.2: {}
 
+  msw@2.4.2(graphql@16.9.0)(typescript@5.3.3):
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.0
+      '@bundled-es-modules/statuses': 1.0.1
+      '@bundled-es-modules/tough-cookie': 0.1.6
+      '@inquirer/confirm': 3.2.0
+      '@mswjs/interceptors': 0.29.1
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.5
+      chalk: 4.1.2
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.2.2
+      strict-event-emitter: 0.5.1
+      type-fest: 4.26.0
+      yargs: 17.7.2
+    optionalDependencies:
+      graphql: 16.9.0
+      typescript: 5.3.3
+
+  mute-stream@1.0.0: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -7887,6 +8147,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  outvariant@1.4.3: {}
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -7932,6 +8194,8 @@ snapshots:
     dependencies:
       lru-cache: 10.2.0
       minipass: 7.1.2
+
+  path-to-regexp@6.2.2: {}
 
   path-type@4.0.0: {}
 
@@ -8033,6 +8297,8 @@ snapshots:
       react-is: 16.13.1
 
   proxy-from-env@1.1.0: {}
+
+  psl@1.9.0: {}
 
   punycode@2.3.1: {}
 
@@ -8331,7 +8597,11 @@ snapshots:
     dependencies:
       type-fest: 0.7.1
 
+  statuses@2.0.1: {}
+
   streamsearch@1.1.0: {}
+
+  strict-event-emitter@0.5.1: {}
 
   string-argv@0.3.2: {}
 
@@ -8532,6 +8802,13 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.9.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
   tr46@0.0.3: {}
 
   trim-newlines@3.0.1: {}
@@ -8559,6 +8836,8 @@ snapshots:
 
   type-fest@0.20.2: {}
 
+  type-fest@0.21.3: {}
+
   type-fest@0.6.0: {}
 
   type-fest@0.7.1: {}
@@ -8566,6 +8845,8 @@ snapshots:
   type-fest@0.8.1: {}
 
   type-fest@3.13.1: {}
+
+  type-fest@4.26.0: {}
 
   typed-array-buffer@1.0.1:
     dependencies:
@@ -8605,6 +8886,8 @@ snapshots:
 
   undici-types@5.26.5: {}
 
+  undici-types@6.19.8: {}
+
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -8615,6 +8898,8 @@ snapshots:
   unicode-match-property-value-ecmascript@2.1.0: {}
 
   unicode-property-aliases-ecmascript@2.1.0: {}
+
+  universalify@0.2.0: {}
 
   unplugin@1.0.1:
     dependencies:
@@ -8750,6 +9035,12 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -8795,3 +9086,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors-cjs@2.1.2: {}

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,284 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const PACKAGE_VERSION = '2.4.2'
+const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Generate unique request ID.
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId))
+})
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const responseClone = response.clone()
+
+      sendToClient(
+        client,
+        {
+          type: 'RESPONSE',
+          payload: {
+            requestId,
+            isMockedResponse: IS_MOCKED_RESPONSE in response,
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            body: responseClone.body,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+          },
+        },
+        [responseClone.body],
+      )
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = request.clone()
+
+  function passthrough() {
+    const headers = Object.fromEntries(requestClone.headers.entries())
+
+    // Remove internal MSW request header so the passthrough request
+    // complies with any potential CORS preflight checks on the server.
+    // Some servers forbid unknown request headers.
+    delete headers['x-msw-intention']
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const requestBuffer = await request.arrayBuffer()
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        url: request.url,
+        mode: request.mode,
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        cache: request.cache,
+        credentials: request.credentials,
+        destination: request.destination,
+        integrity: request.integrity,
+        redirect: request.redirect,
+        referrer: request.referrer,
+        referrerPolicy: request.referrerPolicy,
+        body: requestBuffer,
+        keepalive: request.keepalive,
+      },
+    },
+    [requestBuffer],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(
+      message,
+      [channel.port2].concat(transferrables.filter(Boolean)),
+    )
+  })
+}
+
+async function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import localFont from "next/font/local";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import Provider from "@/components/Provider";
+import MswProvider from "@/components/MswProvider";
 import type { Metadata } from "next";
 import Header from "@/components/common/Header";
 import NavigationFooter from "@/components/common/Footer";
@@ -36,6 +37,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="ko" data-theme="light" className={`${pretendard.variable}`}>
       <GoogleAnalytics gaId="G-6PY1WDK5P6" />
       <body className={pretendard.className}>
+        <MswProvider />
         <Provider>
           <div className="relative h-[100dvh] w-[100dvw] overflow-hidden">
             <Header />

--- a/src/components/MswProvider.tsx
+++ b/src/components/MswProvider.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function MswProvider() {
+  useEffect(() => {
+    if (process.env.NODE_ENV === "development") {
+      if (typeof window === "undefined") {
+        (async () => {
+          const { server } = await import("@/mocks/server");
+          server.listen();
+        })();
+      } else {
+        (async () => {
+          const { worker } = await import("@/mocks/browser");
+          worker.start({
+            onUnhandledRequest: "bypass",
+          });
+        })();
+      }
+    }
+  });
+
+  return null;
+}

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from "msw/browser";
+import { handler } from "./handlers";
+
+export const worker = setupWorker(...handler);

--- a/src/mocks/data/chats.ts
+++ b/src/mocks/data/chats.ts
@@ -1,0 +1,23 @@
+import { ChatMessage } from "@/types/chat";
+import { zzals } from "./zzals";
+
+export const chats: ChatMessage[] = [
+  {
+    nickname: "익명1",
+    email: "익명1@naver.com",
+    message: zzals[0].path,
+    createdAt: "임시 날짜 1",
+  },
+  {
+    nickname: "익명2",
+    email: "익명2@google.com",
+    message: zzals[2].path,
+    createdAt: "임시 날짜 2",
+  },
+  {
+    nickname: "익명3",
+    email: "익명3@naver.com",
+    message: zzals[3].path,
+    createdAt: "임시 날짜 3",
+  },
+];

--- a/src/mocks/data/reports.ts
+++ b/src/mocks/data/reports.ts
@@ -1,0 +1,16 @@
+import { Report } from "@/types/report";
+
+export const reports: Report[] = [
+  {
+    imageId: 2,
+    imageTitle: "박명수",
+    lastReportAt: "마지막 신고 시간",
+    reportCount: 3,
+  },
+  {
+    imageId: 1,
+    imageTitle: "무한도전",
+    lastReportAt: "마지막 신고 시간",
+    reportCount: 3,
+  },
+];

--- a/src/mocks/data/tags.ts
+++ b/src/mocks/data/tags.ts
@@ -1,0 +1,54 @@
+import { Tag } from "@/types/tag";
+
+export const MockTags: Tag[] = [
+  {
+    tagId: 1,
+    tagName: "강아지",
+    count: 25,
+  },
+  {
+    tagId: 2,
+    tagName: "무한도전",
+    count: 22,
+  },
+  {
+    tagId: 3,
+    tagName: "박명수",
+    count: 19,
+  },
+  {
+    tagId: 4,
+    tagName: "루피",
+    count: 14,
+  },
+  {
+    tagId: 5,
+    tagName: "짱구",
+    count: 10,
+  },
+  {
+    tagId: 6,
+    tagName: "맹구",
+    count: 12,
+  },
+  {
+    tagId: 7,
+    tagName: "유재석",
+    count: 8,
+  },
+  {
+    tagId: 8,
+    tagName: "분노",
+    count: 6,
+  },
+  {
+    tagId: 9,
+    tagName: "신남",
+    count: 4,
+  },
+  {
+    tagId: 10,
+    tagName: "졸림",
+    count: 3,
+  },
+];

--- a/src/mocks/data/zzals.ts
+++ b/src/mocks/data/zzals.ts
@@ -1,0 +1,64 @@
+import { GetMyHomeZzalsResponse } from "@/types/zzal.dto";
+
+export const zzals: GetMyHomeZzalsResponse[] = [
+  {
+    imageId: 1,
+    path: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSvo_l4pc8yVopI9mR1zfXgkNW-GVzLFoiRFQ&s",
+    title: "무한도전",
+    imageLikeYn: false,
+  },
+  {
+    imageId: 2,
+    path: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSZ-9ZPc2OfHNKAwQlV8CeHEPgJID-2ba5l7Q&s",
+    title: "박명수",
+    imageLikeYn: false,
+  },
+  {
+    imageId: 3,
+    path: "https://mblogthumb-phinf.pstatic.net/MjAyMTAxMDVfMjE5/MDAxNjA5ODA0NDYxODAx.ieWcq6luZGB9apxLjS_uh-ROYCQS61ubqCW_pA2fTrMg.Zx56vtprvTOoc0sn9oy7eyWGj8TXXlpClSEoWFehQnMg.PNG.bluelaz1103/SE-c3e732d3-5ceb-423f-bbb7-26cf288fe3e0.png?type=w800",
+    title: "강아지",
+    imageLikeYn: false,
+  },
+  {
+    imageId: 4,
+    path: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ_tNt-_ForndzbTEayUOp557zR2mSIfzVhVw&s",
+    title: "루피",
+    imageLikeYn: false,
+  },
+  {
+    imageId: 5,
+    path: "https://sitem.ssgcdn.com/87/70/47/item/1000026477087_i1_750.jpg",
+    title: "짱구",
+    imageLikeYn: false,
+  },
+  {
+    imageId: 6,
+    path: "https://talkimg.imbc.com/TVianUpload/tvian/TViews/image/2022/06/25/3370abfe-c3fd-4371-954a-7ac2d6a392bd.jpg",
+    title: "유재석",
+    imageLikeYn: false,
+  },
+  {
+    imageId: 7,
+    path: "https://img1.daumcdn.net/thumb/R720x0.q80/?scode=mtistory2&fname=https%3A%2F%2Ft1.daumcdn.net%2Fcfile%2Ftistory%2F99F71B435D0E28C708",
+    title: "분노",
+    imageLikeYn: false,
+  },
+  {
+    imageId: 8,
+    path: "https://i.namu.wiki/i/9or_SWMZZwADwmILqRyK_50R_-h1SsI7UApSl0-k-u5JP_aXhXvHgCfwMb5RVnNih09z6usjw2ltPdjsxeQCIQ.webp",
+    title: "맹구",
+    imageLikeYn: false,
+  },
+  {
+    imageId: 9,
+    path: "https://i.namu.wiki/i/9or_SWMZZwADwmILqRyK_50R_-h1SsI7UApSl0-k-u5JP_aXhXvHgCfwMb5RVnNih09z6usjw2ltPdjsxeQCIQ.webp",
+    title: "신남",
+    imageLikeYn: false,
+  },
+  {
+    imageId: 10,
+    path: "https://www.focuscolorado.net/bbs/download.php?table=bbs_11&savefilename=bbs_11_5860.jpg&filename=%EA%B0%9C%EC%A1%B8%EB%A6%BC.jpg",
+    title: "졸림",
+    imageLikeYn: false,
+  },
+];

--- a/src/mocks/handlers/chatHandlers.ts
+++ b/src/mocks/handlers/chatHandlers.ts
@@ -17,6 +17,6 @@ export const chatHandlers = [
       createdAt: "임시 날짜 1",
     });
 
-    return HttpResponse.json({ status: 200 });
+    return HttpResponse.json();
   }),
 ];

--- a/src/mocks/handlers/chatHandlers.ts
+++ b/src/mocks/handlers/chatHandlers.ts
@@ -1,0 +1,22 @@
+import { http, HttpResponse } from "msw";
+import { GetChatResponse } from "@/types/chat.dto";
+import { chats } from "../data/chats";
+import { zzals } from "../data/zzals";
+
+const CHAT_BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/v1/chat`;
+
+export const chatHandlers = [
+  http.get(CHAT_BASE_URL, () => HttpResponse.json<GetChatResponse>(chats)),
+  http.post(`${CHAT_BASE_URL}/nickname`, async ({ request }) => {
+    const email = (await request.json()) as string;
+
+    chats.push({
+      nickname: "익명4",
+      email,
+      message: zzals[0].path,
+      createdAt: "임시 날짜 1",
+    });
+
+    return HttpResponse.json({ status: 200 });
+  }),
+];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,0 +1,13 @@
+import { authHandlers } from "./authHandlers";
+import { chatHandlers } from "./chatHandlers";
+import { reportHandlers } from "./reportHandlers";
+import { TagHandlers } from "./tagHandlers";
+import { zzalHandlers } from "./zzalHandlers";
+
+export const handler = [
+  ...TagHandlers,
+  ...zzalHandlers,
+  ...reportHandlers,
+  ...chatHandlers,
+  ...authHandlers,
+];

--- a/src/mocks/handlers/reportHandlers.ts
+++ b/src/mocks/handlers/reportHandlers.ts
@@ -12,8 +12,8 @@ export const reportHandlers = [
 
     return HttpResponse.json<GetReportDetailsResponse>(getReport(Number(imageId)));
   }),
-  http.post(`${REPORT_BASE_URL}/:imageId`, () => HttpResponse.json({ status: 200 })),
-  http.delete(`${REPORT_BASE_URL}/:imageId`, () => HttpResponse.json({ status: 200 })),
+  http.post(`${REPORT_BASE_URL}/:imageId`, () => HttpResponse.json()),
+  http.delete(`${REPORT_BASE_URL}/:imageId`, () => HttpResponse.json()),
 ];
 
 const getReport = (id: number) => {

--- a/src/mocks/handlers/reportHandlers.ts
+++ b/src/mocks/handlers/reportHandlers.ts
@@ -1,0 +1,32 @@
+import { http, HttpResponse } from "msw";
+import { GetReportDetailsResponse, GetReportsResponse } from "@/types/report.dto";
+import { reports } from "../data/reports";
+import { zzals } from "../data/zzals";
+
+const REPORT_BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/v1/report`;
+
+export const reportHandlers = [
+  http.get(`${REPORT_BASE_URL}`, () => HttpResponse.json<GetReportsResponse>(reports)),
+  http.get(`${REPORT_BASE_URL}/:imageId`, ({ params }) => {
+    const { imageId } = params;
+
+    return HttpResponse.json<GetReportDetailsResponse>(getReport(Number(imageId)));
+  }),
+  http.post(`${REPORT_BASE_URL}/:imageId`, () => HttpResponse.json({ status: 200 })),
+  http.delete(`${REPORT_BASE_URL}/:imageId`, () => HttpResponse.json({ status: 200 })),
+];
+
+const getReport = (id: number) => {
+  const reportZzal = zzals.filter(({ imageId }) => imageId === id);
+
+  return {
+    imageTitle: String(reportZzal[0].imageId),
+    imageUrl: reportZzal[0].path,
+    reports: [
+      {
+        reportDate: "임시 날짜",
+        reportUserEmail: "익명",
+      },
+    ],
+  };
+};

--- a/src/mocks/handlers/tagHandlers.ts
+++ b/src/mocks/handlers/tagHandlers.ts
@@ -1,0 +1,73 @@
+import { http, HttpResponse } from "msw";
+import {
+  GetPopularTagsResponse,
+  GetTagsResponse,
+  GetTopTagsFromHomeResponse,
+  GetTopTagsFromLikedResponse,
+  GetTopTagsFromUploadedResponse,
+} from "@/types/tag.dto";
+import { Tag } from "@/types/tag";
+import { MockTags } from "@/mocks/data/tags";
+
+const TAG_BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/v1/tag`;
+
+export const TagHandlers = [
+  http.get(`${TAG_BASE_URL}/popular`, () =>
+    HttpResponse.json<GetPopularTagsResponse>(getPopularTags(MockTags)),
+  ),
+  http.get(`${TAG_BASE_URL}/search`, async ({ request }) => {
+    const url = new URL(request.url);
+    const keyword = url.searchParams.get("keyword") as string;
+
+    return HttpResponse.json<GetTagsResponse>(getSearchTag(keyword));
+  }),
+  http.get(TAG_BASE_URL, () => HttpResponse.json<GetTopTagsFromHomeResponse>(getTogTags(MockTags))),
+  http.get(`${TAG_BASE_URL}/me/upload`, () =>
+    HttpResponse.json<GetTopTagsFromUploadedResponse>(getTogTags(MockTags)),
+  ),
+  http.get(`${TAG_BASE_URL}/me/like`, () =>
+    HttpResponse.json<GetTopTagsFromLikedResponse>(getTogTags(MockTags)),
+  ),
+  http.post(TAG_BASE_URL, async ({ request }) => {
+    const data = await request.json();
+    const { name } = data as { name: string };
+    const isExistedTag = MockTags.some(({ tagName }) => tagName === name);
+
+    if (isExistedTag) return;
+
+    MockTags.push({
+      tagId: MockTags.length + 1,
+      tagName: name,
+      count: 1,
+    });
+  }),
+  http.post(`${TAG_BASE_URL}/use`, async ({ request }) => {
+    const data = await request.json();
+    const { name } = data as { name: string };
+
+    MockTags.forEach(({ tagName }, index) => {
+      if (tagName === name) MockTags[index].count += 1;
+    });
+  }),
+];
+
+const getPopularTags = (tags: Tag[]) => {
+  const tempTags = [...tags];
+  tempTags.sort((a, b) => b.count - a.count);
+
+  return tempTags.filter((_, index) => index < 5);
+};
+
+const getSearchTag = (tag: string) => {
+  if (!tag) {
+    return [];
+  }
+
+  const regex = new RegExp(tag, "i");
+
+  return MockTags.filter(({ tagName }) => regex.test(tagName));
+};
+
+const getTogTags = (tags: Tag[]) => {
+  return tags.filter((_, index) => index < 5);
+};

--- a/src/mocks/handlers/tagHandlers.ts
+++ b/src/mocks/handlers/tagHandlers.ts
@@ -33,13 +33,15 @@ export const TagHandlers = [
     const { name } = data as { name: string };
     const isExistedTag = MockTags.some(({ tagName }) => tagName === name);
 
-    if (isExistedTag) return;
+    if (isExistedTag) return HttpResponse.error();
 
     MockTags.push({
       tagId: MockTags.length + 1,
       tagName: name,
       count: 1,
     });
+
+    return HttpResponse.json({ status: 200 });
   }),
   http.post(`${TAG_BASE_URL}/use`, async ({ request }) => {
     const data = await request.json();
@@ -48,6 +50,8 @@ export const TagHandlers = [
     MockTags.forEach(({ tagName }, index) => {
       if (tagName === name) MockTags[index].count += 1;
     });
+
+    return HttpResponse.json({ status: 200 });
   }),
 ];
 

--- a/src/mocks/handlers/tagHandlers.ts
+++ b/src/mocks/handlers/tagHandlers.ts
@@ -41,7 +41,7 @@ export const TagHandlers = [
       count: 1,
     });
 
-    return HttpResponse.json({ status: 200 });
+    return HttpResponse.json();
   }),
   http.post(`${TAG_BASE_URL}/use`, async ({ request }) => {
     const data = await request.json();
@@ -51,7 +51,7 @@ export const TagHandlers = [
       if (tagName === name) MockTags[index].count += 1;
     });
 
-    return HttpResponse.json({ status: 200 });
+    return HttpResponse.json();
   }),
 ];
 

--- a/src/mocks/handlers/zzalHandlers.ts
+++ b/src/mocks/handlers/zzalHandlers.ts
@@ -34,7 +34,7 @@ export const zzalHandlers = [
 
     zzalAddLike(Number(imgId));
 
-    return HttpResponse.json({ status: 200 });
+    return HttpResponse.json();
   }),
   http.post(`${ZZAL_BASE_URL}/:imageId/like/cancel`, ({ request }) => {
     const url = new URL(request.url);
@@ -42,7 +42,7 @@ export const zzalHandlers = [
 
     zzalCancelLike(Number(imgId));
 
-    return HttpResponse.json({ status: 200 });
+    return HttpResponse.json();
   }),
   http.post(ZZAL_BASE_URL, async ({ request }) => {
     const data = await request.formData();
@@ -56,7 +56,7 @@ export const zzalHandlers = [
       return HttpResponse.error();
     }
 
-    return HttpResponse.json({ status: 200 });
+    return HttpResponse.json();
   }),
 ];
 

--- a/src/mocks/handlers/zzalHandlers.ts
+++ b/src/mocks/handlers/zzalHandlers.ts
@@ -49,13 +49,11 @@ export const zzalHandlers = [
     const file = data.get("file");
 
     if (!file) {
-      return new HttpResponse("Missing document", { status: 400 });
+      return HttpResponse.error();
     }
 
     if (!(file instanceof File)) {
-      return new HttpResponse("Uploaded document is not a File", {
-        status: 400,
-      });
+      return HttpResponse.error();
     }
 
     return HttpResponse.json({ status: 200 });

--- a/src/mocks/handlers/zzalHandlers.ts
+++ b/src/mocks/handlers/zzalHandlers.ts
@@ -1,0 +1,96 @@
+import { http, HttpResponse } from "msw";
+import { GetMyHomeZzalsResponse } from "@/types/zzal.dto";
+import { zzals } from "../data/zzals";
+
+const ZZAL_BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/v1/image`;
+
+export const zzalHandlers = [
+  http.get(`${ZZAL_BASE_URL}`, ({ request }) => {
+    const url = new URL(request.url);
+    const tag = url.searchParams.get("tagName") as string;
+
+    return HttpResponse.json<GetMyHomeZzalsResponse[]>(getZzals(tag));
+  }),
+  http.get(`${ZZAL_BASE_URL}/like`, ({ request }) => {
+    const url = new URL(request.url);
+    const tag = url.searchParams.get("tagName") as string;
+
+    return HttpResponse.json<GetMyHomeZzalsResponse[]>(getZzals(tag));
+  }),
+  http.get(`${ZZAL_BASE_URL}/upload`, ({ request }) => {
+    const url = new URL(request.url);
+    const tag = url.searchParams.get("tagName") as string;
+
+    return HttpResponse.json<GetMyHomeZzalsResponse[]>(getZzals(tag));
+  }),
+  http.get(`${ZZAL_BASE_URL}/:imageId`, ({ params }) => {
+    const { imageId } = params;
+
+    return HttpResponse.json(getZzal(Number(imageId)));
+  }),
+  http.post(`${ZZAL_BASE_URL}/:imageId/like`, ({ request }) => {
+    const url = new URL(request.url);
+    const imgId = url.searchParams.get("imageId");
+
+    zzalAddLike(Number(imgId));
+
+    return HttpResponse.json({ status: 200 });
+  }),
+  http.post(`${ZZAL_BASE_URL}/:imageId/like/cancel`, ({ request }) => {
+    const url = new URL(request.url);
+    const imgId = url.searchParams.get("imageId");
+
+    zzalCancelLike(Number(imgId));
+
+    return HttpResponse.json({ status: 200 });
+  }),
+  http.post(ZZAL_BASE_URL, async ({ request }) => {
+    const data = await request.formData();
+    const file = data.get("file");
+
+    if (!file) {
+      return new HttpResponse("Missing document", { status: 400 });
+    }
+
+    if (!(file instanceof File)) {
+      return new HttpResponse("Uploaded document is not a File", {
+        status: 400,
+      });
+    }
+
+    return HttpResponse.json({ status: 200 });
+  }),
+];
+
+const getZzals = (tag: string) => {
+  const regex = new RegExp(tag, "i");
+
+  return zzals.filter(({ title }) => regex.test(title));
+};
+
+const getZzal = (id: number) => {
+  const zzal = zzals.filter(({ imageId }) => imageId === id);
+  return {
+    ...zzal,
+    imageTitle: zzal[0].title,
+    uploadUserId: 1,
+    imgUrl: zzal[0].path,
+    tags: [],
+  };
+};
+
+const zzalAddLike = (id: number) => {
+  zzals.forEach(({ imageId }, index) => {
+    if (imageId === id) {
+      zzals[index].imageLikeYn = true;
+    }
+  });
+};
+
+const zzalCancelLike = (id: number) => {
+  zzals.forEach(({ imageId }, index) => {
+    if (imageId === id) {
+      zzals[index].imageLikeYn = false;
+    }
+  });
+};

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from "msw/node";
+import { handler } from "./handlers";
+
+export const server = setupServer(...handler);


### PR DESCRIPTION
## 📝 작업 내용

## MSW 설치 및 세팅 + 로그인을 제외한 기존 API Mocking 핸들러 구현
> 서버 이관 작업으로 인한 프론트엔드와 백엔드의 비동기적인 작업 진행을 위해 MSW를 도입하였습니다.
MSW는 최신버전으로 설치 하였으며, 서버사이드에서도 API Mocking을 할 수 있도록 하기 위해 setupServer도 설정해주었습니다.

MSW의 프로젝트 구조는 아래와 같이 `data` 부분에는 API Mocking시 반환값으로 전달할 데이터들이 들어있으며, `handler`에는 `data`에 들어있는 데이터들을 반환하기 위한 Mocking 핸들러들이 들어있습니다.
```
📦mocks
 ┣ 📂data
 ┃ ┣ 📜chats.ts
 ┃ ┣ 📜reports.ts
 ┃ ┣ 📜tags.ts
 ┃ ┗ 📜zzals.ts
 ┣ 📂handlers
 ┃ ┣ 📜chatHandlers.ts
 ┃ ┣ 📜index.ts
 ┃ ┣ 📜reportHandlers.ts
 ┃ ┣ 📜tagHandlers.ts
 ┃ ┗ 📜zzalHandlers.ts
 ┣ 📜browser.ts
 ┗ 📜server.ts
```

`NextJS`로 마이그레이션을 위해 선행되는 작업으로 서버 이관 전까지 간단한 테스트용이기에 요청에 실패 할 경우 전반적으로 상태 코드를 설정하지 않고 반환하도록 구현하였습니다. 따라서 요청에 실패 할 경우 `HTTPResponse.error()`를, 요청에 성공할 경우 `HTTPResponse.json()`(200)를 반환하도록 구현하였습니다.

현재 `chatHandlers`의 경우 채팅을 작성하는 작업은 인증 로직에 의해 Mocking이 되지 않고있으며, `reportHandlers`의 경우 이미지 신고 메소드가 별다른 로직없이 바로 성공을 뜻하는 `HTTPResponse.json()`을 반환하고 있습니다. 이는 홈 화면에서 이미지를 신고하여 `data/ report.ts`에 신고된 이미지를 넣어도, 페이지가 이동되면 해당 데이터들이 초기화되므로 데이터가 올바르게 들어갔는지 확인이 불가능하여 바로 `요청 성공` 반환하도록 구현하였습니다.

### OAuth API Mocking 차후 작업으로 전환
OAuth 같은 경우 로그인을 위한 API가 존재하는 것이 아닌 `LoginModal`에서 카카오, 구글, 네이버에 해당하는 OAuth 로그인 페이지로 바로 이동하도록 `a`태그로 구현이되어있습니다. 그러다보니 Mocking할 API가 없어 현재 작업단위에서는 구현하지 않았습니다.

해당 작업은 현재 PR 이후, 바로 다음 작업으로 프론트에서 임시로 API와 이를 사용할 `fetching 로직 + UI + UI 이벤트`를 서버 이관이 완료될 때까지 테스트용으로 사용하기 위해 구현할 예정입니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

📌 `MSW` 폴더 구조가 올바르다고 생각하시는지 궁금합니다.
📌 `handlers` 폴더의 핸들러 파일에서 반환시킬 데이터를 뽑아내는 함수를 `접두사+handlers` 파일 내에서 함께 관리하고 있습니다. 해당 함수들이 공통적으로 사용되지 않고 있어 `utils`로 분리하지 않았는데 다른 분들은 어떻게 생각하시는지 피드백 부탁드립니다.
📌 상태 코드를 체계적으로 반환하고 있지 않습니다. 서버 이관 전까지 잠깐의 테스트를 위한 기능이라 간단하게 `HTTPResponse.error`와 `HTTPResponse.json`으로만 반환을 하고 있는데, 현재 상황에서 상태코드를 조금 더 체계적으로 반환하도록 관리하는 것이 좋을지 궁금합니다.

# 📍 기타 (선택)

> 다른 분들이 참고해야할 사항이 있다면 작성해주세요

close #257 
