### PR TITLE
[#256] Feat: 쿼리 팩토리 적용 및 네트워크 워터폴 최적화

### DIFF
--- a/src/app/(with_chat)/home/Home.tsx
+++ b/src/app/(with_chat)/home/Home.tsx
@@ -40,7 +40,8 @@ const Home = () => {
             imageId={imageId}
             isLiked={imageLikeYn}
             imageIndex={index}
-            queryKey={["homeZzals", selectedTags]}
+            type="home"
+            selectedTags={selectedTags}
           />
         ))}
       </MasonryLayout>

--- a/src/app/(with_chat)/home/page.tsx
+++ b/src/app/(with_chat)/home/page.tsx
@@ -1,20 +1,11 @@
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
-import { getHomeZzals } from "@/apis/zzal";
 import ErrorCaughtHome from "./Home";
+import zzalQueries from "@/hooks/api/zzal/queryKeyFactories";
 
 const ExplorePage = async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchInfiniteQuery({
-    queryKey: ["homeZzals", []],
-    queryFn: ({ pageParam = 0 }) => getHomeZzals({ page: pageParam, selectedTags: [] }),
-    getNextPageParam: (lastPage: unknown, _allPages: unknown, lastPageParam: number) => {
-      if (!lastPage) return;
-
-      return lastPageParam + 1;
-    },
-    initialPageParam: 0,
-  });
+  await queryClient.prefetchInfiniteQuery(zzalQueries.selectedHomeZzals([]));
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/(with_chat)/home/page.tsx
+++ b/src/app/(with_chat)/home/page.tsx
@@ -1,11 +1,15 @@
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 import ErrorCaughtHome from "./Home";
 import zzalQueries from "@/hooks/api/zzal/queryKeyFactories";
+import tagQueries from "@/hooks/api/tag/queryKeyFactories";
 
 const ExplorePage = async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchInfiniteQuery(zzalQueries.selectedHomeZzals([]));
+  await Promise.all([
+    queryClient.prefetchInfiniteQuery(zzalQueries.selectedHomeZzals([])),
+    queryClient.prefetchQuery(tagQueries.topTagsFromHome()),
+  ]);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/(with_chat)/my-liked-zzals/MyLikedZzals.tsx
+++ b/src/app/(with_chat)/my-liked-zzals/MyLikedZzals.tsx
@@ -42,7 +42,8 @@ const MyLikedZzals = () => {
             imageId={imageId}
             isLiked={imageLikeYn}
             imageIndex={index}
-            queryKey={["likedZzals", selectedTags]}
+            type="liked"
+            selectedTags={selectedTags}
           />
         ))}
       </MasonryLayout>

--- a/src/app/(with_chat)/my-liked-zzals/page.tsx
+++ b/src/app/(with_chat)/my-liked-zzals/page.tsx
@@ -1,11 +1,15 @@
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 import ErrorCaughtMyLikedZzals from "./MyLikedZzals";
 import zzalQueries from "@/hooks/api/zzal/queryKeyFactories";
+import tagQueries from "@/hooks/api/tag/queryKeyFactories";
 
 const MyLikedZzalsPage = async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchInfiniteQuery(zzalQueries.selectedMyLikedZzals([]));
+  await Promise.all([
+    queryClient.prefetchInfiniteQuery(zzalQueries.selectedMyLikedZzals([])),
+    queryClient.prefetchQuery(tagQueries.topTagsFromLiked()),
+  ]);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/(with_chat)/my-liked-zzals/page.tsx
+++ b/src/app/(with_chat)/my-liked-zzals/page.tsx
@@ -1,20 +1,11 @@
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
-import { getMyLikedZzals } from "@/apis/zzal";
 import ErrorCaughtMyLikedZzals from "./MyLikedZzals";
+import zzalQueries from "@/hooks/api/zzal/queryKeyFactories";
 
 const MyLikedZzalsPage = async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchInfiniteQuery({
-    queryKey: ["likedZzals", []],
-    queryFn: ({ pageParam = 0 }) => getMyLikedZzals({ page: pageParam, selectedTags: [] }),
-    getNextPageParam: (lastPage: unknown, _allPages: unknown, lastPageParam: number) => {
-      if (!lastPage) return;
-
-      return lastPageParam + 1;
-    },
-    initialPageParam: 0,
-  });
+  await queryClient.prefetchInfiniteQuery(zzalQueries.selectedMyLikedZzals([]));
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/(with_chat)/my-uploaded-zzals/MyUploadedZzals.tsx
+++ b/src/app/(with_chat)/my-uploaded-zzals/MyUploadedZzals.tsx
@@ -42,7 +42,8 @@ const MyUploadedZzals = () => {
             imageId={imageId}
             imageIndex={index}
             isLiked={imageLikeYn}
-            queryKey={["uploadedZzals", selectedTags]}
+            type="uploaded"
+            selectedTags={selectedTags}
             hasDeleteButton={true}
           />
         ))}

--- a/src/app/(with_chat)/my-uploaded-zzals/page.tsx
+++ b/src/app/(with_chat)/my-uploaded-zzals/page.tsx
@@ -1,26 +1,13 @@
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
-import { getMyUploadedZzals } from "@/apis/zzal";
-import { getTopTagsFromUploaded } from "@/apis/tag";
 import ErrorCaughtMyUploadedZzals from "./MyUploadedZzals";
+import zzalQueries from "@/hooks/api/zzal/queryKeyFactories";
+import tagQueries from "@/hooks/api/tag/queryKeyFactories";
 
 const MyUploadedZzalsPage = async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchInfiniteQuery({
-    queryKey: ["uploadedZzals", []],
-    queryFn: ({ pageParam = 0 }) => getMyUploadedZzals({ page: pageParam, selectedTags: [] }),
-    getNextPageParam: (lastPage: unknown, _allPages: unknown, lastPageParam: number) => {
-      if (!lastPage) return;
-
-      return lastPageParam + 1;
-    },
-    initialPageParam: 0,
-  });
-
-  await queryClient.prefetchQuery({
-    queryKey: ["topTagsFromUploaded"],
-    queryFn: () => getTopTagsFromUploaded(),
-  });
+  await queryClient.prefetchInfiniteQuery(zzalQueries.selectedMyUploadedZzals([]));
+  await queryClient.prefetchQuery(tagQueries.topTagsFromUploaded());
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/(with_chat)/my-uploaded-zzals/page.tsx
+++ b/src/app/(with_chat)/my-uploaded-zzals/page.tsx
@@ -6,8 +6,10 @@ import tagQueries from "@/hooks/api/tag/queryKeyFactories";
 const MyUploadedZzalsPage = async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchInfiniteQuery(zzalQueries.selectedMyUploadedZzals([]));
-  await queryClient.prefetchQuery(tagQueries.topTagsFromUploaded());
+  await Promise.all([
+    queryClient.prefetchInfiniteQuery(zzalQueries.selectedMyUploadedZzals([])),
+    queryClient.prefetchQuery(tagQueries.topTagsFromUploaded()),
+  ]);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/components/ImageDetailModal/index.tsx
+++ b/src/components/ImageDetailModal/index.tsx
@@ -9,7 +9,7 @@ import ReportConfirmModal from "@/components/ReportConfirmModal";
 import { cn } from "@/utils/tailwind";
 import { copyZzal, downloadZzal } from "@/utils/zzalUtils";
 import { debounce } from "@/utils/debounce";
-import { ZzalType } from "@/types/queryKey";
+import { ZzalCardType } from "@/types/zzal";
 import ButtonWithIcon from "./ButtonWithIcon";
 import TagSlider from "@/components/common/TagSlider";
 import Modal from "@/components/common/modals/Modal";
@@ -26,7 +26,8 @@ interface Props {
   onClose: () => void;
   imageId: number;
   imageIndex: number;
-  queryKey: [ZzalType, string[]];
+  type: ZzalCardType;
+  selectedTags: string[];
 }
 
 interface CustomErrorResponse {
@@ -37,13 +38,15 @@ interface CustomErrorResponse {
 interface ImageDetailModalContentProps {
   imageId: number;
   imageIndex: number;
-  queryKey: [ZzalType, string[]];
+  type: ZzalCardType;
+  selectedTags: string[];
 }
 
 const ImageDetailModalContent = ({
   imageId,
   imageIndex,
-  queryKey,
+  type,
+  selectedTags,
 }: ImageDetailModalContentProps) => {
   const [isTagNavigatorOpen, setIsTagNavigatorOpen] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
@@ -52,8 +55,8 @@ const ImageDetailModalContent = ({
   const reportConfirmOverlay = useOverlay();
   const { isLiked, imageUrl, tagNames, imageTitle } = zzalDetails;
   const { role } = useAtomValue($userInformation);
-  const { addImageLike } = useAddImageLike(imageIndex, queryKey, imageId);
-  const { removeImageLike } = useRemoveImageLike(imageIndex, queryKey, imageId);
+  const { addImageLike } = useAddImageLike(imageIndex, type, selectedTags, imageId);
+  const { removeImageLike } = useRemoveImageLike(imageIndex, type, selectedTags, imageId);
   const setPreviewImage = useSetAtom($setMessagePreview);
   const onClose = useModalContext();
 
@@ -236,11 +239,16 @@ const ImageDetailModalContent = ({
   );
 };
 
-const ImageDetailModal = ({ isOpen, onClose, imageId, imageIndex, queryKey }: Props) => {
+const ImageDetailModal = ({ isOpen, onClose, imageId, imageIndex, type, selectedTags }: Props) => {
   return (
     <Suspense fallback={"...pending"}>
       <Modal isOpen={isOpen} onClose={onClose} size="sm">
-        <ImageDetailModalContent imageId={imageId} imageIndex={imageIndex} queryKey={queryKey} />
+        <ImageDetailModalContent
+          imageId={imageId}
+          imageIndex={imageIndex}
+          type={type}
+          selectedTags={selectedTags}
+        />
       </Modal>
     </Suspense>
   );

--- a/src/components/common/ZzalCard.tsx
+++ b/src/components/common/ZzalCard.tsx
@@ -7,7 +7,7 @@ import { Trash2 } from "lucide-react";
 import { sendGAEvent } from "@next/third-parties/google";
 import { cn } from "@/utils/tailwind";
 import { copyZzal } from "@/utils/zzalUtils";
-import { ZzalType } from "@/types/queryKey";
+import { ZzalCardType } from "@/types/zzal";
 import ImageDetailModal from "../ImageDetailModal";
 import { useAddImageLike } from "@/hooks/api/zzal/useAddImageLike";
 import { $setMessagePreview } from "@/store/chat";
@@ -21,7 +21,8 @@ interface Props {
   imageId: number;
   isLiked: boolean;
   imageIndex: number;
-  queryKey: [ZzalType, string[]];
+  type: ZzalCardType;
+  selectedTags: string[];
   width?: number | string;
   className?: string;
   hasDeleteButton?: boolean;
@@ -33,7 +34,8 @@ const ZzalCard = ({
   imageId,
   isLiked,
   imageIndex,
-  queryKey,
+  type,
+  selectedTags,
   width = 72,
   className,
   hasDeleteButton = false,
@@ -46,7 +48,8 @@ const ZzalCard = ({
         isOpen={isOpen}
         onClose={close}
         imageId={imageId}
-        queryKey={queryKey}
+        type={type}
+        selectedTags={selectedTags}
         imageIndex={imageIndex}
       />
     ));
@@ -64,7 +67,8 @@ const ZzalCard = ({
           imageId={imageId}
           isLiked={isLiked}
           imageIndex={imageIndex}
-          queryKey={queryKey}
+          type={type}
+          selectedTags={selectedTags}
         />
       </div>
       <figure className="h-fit transition duration-300 ease-in-out hover:brightness-75">
@@ -85,11 +89,12 @@ interface LikeButtonProps {
   imageId: number;
   isLiked: boolean;
   imageIndex: number;
-  queryKey: [ZzalType, string[]];
+  type: ZzalCardType;
+  selectedTags: string[];
 }
-const LikeButton = ({ imageId, isLiked, imageIndex, queryKey }: LikeButtonProps) => {
-  const { addImageLike } = useAddImageLike(imageIndex, queryKey, imageId);
-  const { removeImageLike } = useRemoveImageLike(imageIndex, queryKey, imageId);
+const LikeButton = ({ imageId, isLiked, imageIndex, type, selectedTags }: LikeButtonProps) => {
+  const { addImageLike } = useAddImageLike(imageIndex, type, selectedTags, imageId);
+  const { removeImageLike } = useRemoveImageLike(imageIndex, type, selectedTags, imageId);
 
   const handleClickImageLike = () => {
     if (!isLiked) {

--- a/src/hooks/api/auth/useGetUserInformation.ts
+++ b/src/hooks/api/auth/useGetUserInformation.ts
@@ -1,16 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
-import { getUserInformation } from "@/apis/auth";
 import { getLocalStorage } from "@/utils/localStorage";
+import authQueries from "./queryKeyFactories";
 import { REFRESH_TOKEN } from "@/constants/auth";
 
 const useGetUserInformation = () => {
   const refreshToken = getLocalStorage(REFRESH_TOKEN);
 
-  const { data: userInformation, ...rest } = useQuery({
-    queryKey: ["userInformation"],
-    queryFn: getUserInformation,
-    enabled: !!refreshToken,
-  });
+  const { data: userInformation, ...rest } = useQuery(authQueries.userInformation(refreshToken));
 
   return { userInformation, ...rest };
 };

--- a/src/hooks/api/chat/useGetChat.ts
+++ b/src/hooks/api/chat/useGetChat.ts
@@ -1,24 +1,9 @@
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { getChat } from "@/apis/chat";
+import chatQueries from "./queryKeyFactories";
 
 const useGetChat = () => {
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage, ...rest } =
-    useSuspenseInfiniteQuery({
-      queryKey: ["chat"],
-      queryFn: async ({ pageParam = 0 }) => await getChat(pageParam),
-      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
-        if (lastPage.length === 0) return;
-
-        return lastPageParam + 1;
-      },
-      select: (data) => ({
-        pages: [...data.pages].reverse(),
-        pageParams: [...data.pageParams],
-      }),
-      initialPageParam: 0,
-      refetchOnWindowFocus: false,
-      refetchOnMount: false,
-    });
+    useSuspenseInfiniteQuery(chatQueries.messages());
 
   const handleFetchNextPage = () => {
     if (hasNextPage && !isFetchingNextPage) {

--- a/src/hooks/api/report/useGetReportDetails.ts
+++ b/src/hooks/api/report/useGetReportDetails.ts
@@ -1,11 +1,8 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { getReportDetails } from "@/apis/report";
+import reportQueries from "./queryKeyFactories";
 
 const useGetReportsDetails = (imageId: string) => {
-  const { data: reportDetails, ...rest } = useSuspenseQuery({
-    queryKey: ["reportDetails", imageId],
-    queryFn: () => getReportDetails(imageId),
-  });
+  const { data: reportDetails, ...rest } = useSuspenseQuery(reportQueries.report(imageId));
 
   return { reportDetails, ...rest };
 };

--- a/src/hooks/api/report/useGetReports.ts
+++ b/src/hooks/api/report/useGetReports.ts
@@ -1,18 +1,9 @@
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { getReports } from "@/apis/report";
+import reportQueries from "./queryKeyFactories";
 
 const useGetReports = () => {
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage, ...rest } =
-    useSuspenseInfiniteQuery({
-      queryKey: ["reports"],
-      queryFn: ({ pageParam = 0 }) => getReports(pageParam),
-      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
-        if (!lastPage) return;
-
-        return lastPageParam + 1;
-      },
-      initialPageParam: 0,
-    });
+    useSuspenseInfiniteQuery(reportQueries.reports());
 
   const handleFetchNextPage = () => {
     if (hasNextPage && !isFetchingNextPage) {

--- a/src/hooks/api/tag/useGetPopularTags.ts
+++ b/src/hooks/api/tag/useGetPopularTags.ts
@@ -1,11 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { getPopularTags } from "@/apis/tag";
+import tagQueries from "./queryKeyFactories";
 
 const useGetPopularTags = () => {
-  const { data, ...rest } = useQuery({
-    queryKey: ["popularTags"],
-    queryFn: () => getPopularTags(),
-  });
+  const { data, ...rest } = useQuery(tagQueries.popularTags());
 
   return {
     popularTags: data || [],

--- a/src/hooks/api/tag/useGetTags.ts
+++ b/src/hooks/api/tag/useGetTags.ts
@@ -1,14 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { getSearchTag } from "@/apis/tag";
+import tagQueries from "./queryKeyFactories";
 
 export const useGetTags = (tag: string) => {
-  const MAX_TAG_RESPONSE_COUNT = 10;
-
-  const { data, ...rest } = useQuery({
-    queryKey: ["tag", tag] as const,
-    queryFn: () => getSearchTag(tag),
-    select: (tags) => tags.filter((_tag, index) => index < MAX_TAG_RESPONSE_COUNT),
-  });
+  const { data, ...rest } = useQuery(tagQueries.searchResult(tag));
 
   return {
     autoCompletedTags: data || [],

--- a/src/hooks/api/tag/useGetTopTagsFromHome.ts
+++ b/src/hooks/api/tag/useGetTopTagsFromHome.ts
@@ -1,11 +1,8 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { getTopTagsFromHome } from "@/apis/tag";
+import tagQueries from "./queryKeyFactories";
 
 const useGetTopTagsFromHome = () => {
-  const { data, ...rest } = useSuspenseQuery({
-    queryKey: ["topTagsFromHome"],
-    queryFn: getTopTagsFromHome,
-  });
+  const { data, ...rest } = useSuspenseQuery(tagQueries.topTagsFromHome());
 
   return {
     topTags: data,

--- a/src/hooks/api/tag/useGetTopTagsFromLiked.ts
+++ b/src/hooks/api/tag/useGetTopTagsFromLiked.ts
@@ -1,11 +1,8 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { getTopTagsFromLiked } from "@/apis/tag";
+import tagQueries from "./queryKeyFactories";
 
 const useGetTopTagsFromLiked = () => {
-  const { data, ...rest } = useSuspenseQuery({
-    queryKey: ["topTagsFromLiked"],
-    queryFn: getTopTagsFromLiked,
-  });
+  const { data, ...rest } = useSuspenseQuery(tagQueries.topTagsFromLiked());
 
   return {
     topTags: data,

--- a/src/hooks/api/tag/useGetTopTagsFromUploaded.ts
+++ b/src/hooks/api/tag/useGetTopTagsFromUploaded.ts
@@ -1,11 +1,8 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { getTopTagsFromUploaded } from "@/apis/tag";
+import tagQueries from "./queryKeyFactories";
 
 const useGetTopTagsFromUploaded = () => {
-  const { data, ...rest } = useSuspenseQuery({
-    queryKey: ["topTagsFromUploaded"],
-    queryFn: getTopTagsFromUploaded,
-  });
+  const { data, ...rest } = useSuspenseQuery(tagQueries.topTagsFromUploaded());
 
   return {
     topTags: data,

--- a/src/hooks/api/zzal/useGetMyUploadedZzals.ts
+++ b/src/hooks/api/zzal/useGetMyUploadedZzals.ts
@@ -1,22 +1,13 @@
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { useAtom } from "jotai";
-import { getMyUploadedZzals } from "@/apis/zzal";
+import zzalQueries from "./queryKeyFactories";
 import { $selectedTags } from "@/store/tag";
 
 const useGetMyUploadedZzals = () => {
   const [selectedTags] = useAtom($selectedTags);
 
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage, ...rest } =
-    useSuspenseInfiniteQuery({
-      queryKey: ["uploadedZzals", selectedTags],
-      queryFn: ({ pageParam = 0 }) => getMyUploadedZzals({ page: pageParam, selectedTags }),
-      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
-        if (!lastPage) return;
-
-        return lastPageParam + 1;
-      },
-      initialPageParam: 0,
-    });
+    useSuspenseInfiniteQuery(zzalQueries.selectedMyUploadedZzals(selectedTags));
 
   const handleFetchNextPage = () => {
     if (hasNextPage && !isFetchingNextPage) {

--- a/src/hooks/api/zzal/useRemoveImageLike.ts
+++ b/src/hooks/api/zzal/useRemoveImageLike.ts
@@ -1,12 +1,18 @@
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 import { deleteImageLike } from "@/apis/zzal";
-import { GetZzalResponse } from "@/types/zzal.dto";
-import { ZzalType } from "@/types/queryKey";
-import { GetZzalDetailsResponse } from "@/types/zzal.dto";
+import { ZzalCardType } from "@/types/zzal";
+import zzalQueries from "./queryKeyFactories";
+
+const queryPerType = {
+  liked: zzalQueries.selectedMyLikedZzals,
+  home: zzalQueries.selectedHomeZzals,
+  uploaded: zzalQueries.selectedMyUploadedZzals,
+};
 
 export const useRemoveImageLike = (
   imageIndex: number,
-  zzalKey: [ZzalType, string[]],
+  type: ZzalCardType,
+  selectedTags: string[],
   imageId: number,
 ) => {
   const queryClient = useQueryClient();
@@ -15,22 +21,19 @@ export const useRemoveImageLike = (
     mutationFn: (imageId: number) => deleteImageLike(imageId),
     onMutate: async () => {
       await Promise.all([
-        queryClient.cancelQueries({ queryKey: [...zzalKey] }),
-        queryClient.cancelQueries({ queryKey: ["zzalDetails", imageId] }),
+        queryClient.cancelQueries({ queryKey: queryPerType[type](selectedTags).queryKey }),
+        queryClient.cancelQueries({ queryKey: zzalQueries.detail(imageId).queryKey }),
       ]);
 
-      const zzalOldData = queryClient.getQueryData<GetZzalResponse>([...zzalKey]);
-      const zzalDetailOldData = queryClient.getQueryData<GetZzalDetailsResponse>([
-        "zzalDetails",
-        imageId,
-      ]);
+      const zzalOldData = queryClient.getQueryData(queryPerType[type](selectedTags).queryKey);
+      const zzalDetailOldData = queryClient.getQueryData(zzalQueries.detail(imageId).queryKey);
 
       if (!zzalOldData) return;
 
       if (zzalDetailOldData) {
         const zzalDetailUpdatedData = JSON.parse(JSON.stringify(zzalDetailOldData));
         zzalDetailUpdatedData.imageLikeYn = false;
-        queryClient.setQueryData(["zzalDetails", imageId], zzalDetailUpdatedData);
+        queryClient.setQueryData(zzalQueries.detail(imageId).queryKey, zzalDetailUpdatedData);
       }
 
       const zzalUpdatedData = JSON.parse(
@@ -40,17 +43,17 @@ export const useRemoveImageLike = (
         }),
       );
       zzalUpdatedData.pages[imageIndex].imageLikeYn = false;
-      queryClient.setQueryData([...zzalKey], zzalUpdatedData);
+      queryClient.setQueryData(queryPerType[type](selectedTags).queryKey, zzalUpdatedData);
 
       return { zzalOldData, zzalDetailOldData };
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["likedZzals"] });
+      queryClient.invalidateQueries({ queryKey: zzalQueries.myLikedZzals() });
     },
     onError: (_error, _zzalId, context) => {
-      queryClient.setQueryData([...zzalKey], context?.zzalOldData);
+      queryClient.setQueryData(queryPerType[type](selectedTags).queryKey, context?.zzalOldData);
       if (context?.zzalDetailOldData) {
-        queryClient.setQueryData(["zzalDetails", imageId], context?.zzalDetailOldData);
+        queryClient.setQueryData(zzalQueries.detail(imageId).queryKey, context?.zzalDetailOldData);
       }
     },
   });

--- a/src/types/zzal.ts
+++ b/src/types/zzal.ts
@@ -1,0 +1,1 @@
+export type ZzalCardType = "liked" | "uploaded" | "home";


### PR DESCRIPTION
# [#256] Feat: 쿼리 팩토리 적용 및 네트워크 워터폴 최적화

## 📝 작업 내용

PR [[#254] Modify: query factory 수정](https://github.com/zzalmyu/zzalmyu-frontend/pull/255) 에서 수정된 쿼리 팩토리를 프로젝트 전역에 적용하는 작업을 진행했습니다
server 및 client에서 발생하는 네트워크 워터폴을 최적화 하는 작업을 진행했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

클라이언트 사이드에서 발생하는 주요 네트워크 워터폴은 `Home.tsx`, `MyLikedZzals.tsx`, `MyUploadedZzals.tsx`으로 판단됩니다. 모두 다수의 data fetching을 `useSuspenseQuery`또는 `useSuspenseInfiniteQuery`를 사용하여 진행됩니다. 컴포넌트를 suspend하는 함수를 사용하기 때문에 각 data fetch는 직렬적으로 진행됩니다. 
useSuspenseQueries를 사용하는 방법도 있지만 3 경우 모두 infiniteQuery가 포함되어 데이터 작업이 복잡해져서 보류했습니다.
tag관련 data fetch를 `useQuery`를 사용해서 하는 방법을 고민해 보고 있습니다. 대신, 해당 api의 data에 의존적인 `useEffect`문이 있어 의도치 않은 side effect가 발생할 우려가 있어 보류했습니다.

# 📍 기타 (선택)

> 다른 분들이 참고해야할 사항이 있다면 작성해주세요

close #256
