### PR TITLE
[#264] Fix: 구현되지 않은 authHandler를 import 함으로써 생기는 버그 수정

### DIFF
--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,13 +1,6 @@
-import { authHandlers } from "./authHandlers";
 import { chatHandlers } from "./chatHandlers";
 import { reportHandlers } from "./reportHandlers";
 import { TagHandlers } from "./tagHandlers";
 import { zzalHandlers } from "./zzalHandlers";
 
-export const handler = [
-  ...TagHandlers,
-  ...zzalHandlers,
-  ...reportHandlers,
-  ...chatHandlers,
-  ...authHandlers,
-];
+export const handler = [...TagHandlers, ...zzalHandlers, ...reportHandlers, ...chatHandlers];


### PR DESCRIPTION
## 📝 작업 내용

구현되지 않은 authHandler를 import 하며 발생한 로컬 서버 실행 불가 버그를 authHandler를 import 하지 않음으로써 해결한 버그입니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

# 📍 기타 (선택)

close #264
